### PR TITLE
'new' prefix added to class builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .idea
+*.iml
 
 .gradle
 build/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient
 fun main(args: Array<String>) {
   val client = DefaultKubernetesClient().inNamespace("default")
   client.extensions().ingresses().createOrReplace(
-    ingress {
+    newIngress {
       metadata {
         name = "example-ingress"
       }
@@ -65,6 +65,9 @@ baseService.apply {
 Here is an example of `BaseDeployment` that defines a deployment with one replica and mounts a secret that can be used by the service.
 
 ```kotlin
+import io.fabric8.kubernetes.api.model.IntOrString
+import io.fabric8.kubernetes.api.model.extensions.Deployment
+
 class BaseDeployment : Deployment {
   constructor(serviceName: String) {
     metadata {
@@ -85,24 +88,24 @@ class BaseDeployment : Deployment {
         }
         spec {
           containers = listOf(
-            container {
-              name  = "$serviceName-service"
+            newContainer {
+              name = "$serviceName-service"
               image = "gcr.io/fkorotkov/$serviceName-service:latest"
               volumeMounts = listOf(
-                volumeMount {
+                newVolumeMount {
                   name = "gcp-credentials"
                   mountPath = "/etc/credentials"
                   readOnly = true
                 }
               )
               env = listOf(
-                envVar {
+                newEnvVar {
                   name = "GOOGLE_APPLICATION_CREDENTIALS"
                   value = "/etc/credentials/service-account-credentials.json"
                 }
               )
               ports = listOf(
-                containerPort {
+                newContainerPort {
                   containerPort = 8080
                 }
               )
@@ -124,7 +127,7 @@ class BaseDeployment : Deployment {
             }
           )
           volumes = listOf(
-            volume {
+            newVolume {
               name = "gcp-credentials"
               secret {
                 secretName = "gcp-credentials"

--- a/example/src/main/kotlin/BaseDeployment.kt
+++ b/example/src/main/kotlin/BaseDeployment.kt
@@ -1,0 +1,75 @@
+import com.fkorotkov.kubernetes.*
+import io.fabric8.kubernetes.api.model.IntOrString
+import io.fabric8.kubernetes.api.model.extensions.Deployment
+
+class BaseDeployment : Deployment {
+  constructor(serviceName: String) {
+    metadata {
+      name = "$serviceName-service-deployment"
+      labels = mapOf(
+        "app" to serviceName,
+        "tier" to "backend"
+      )
+    }
+    spec {
+      replicas = 1
+      template {
+        metadata {
+          labels = mapOf(
+            "app" to serviceName,
+            "tier" to "backend"
+          )
+        }
+        spec {
+          containers = listOf(
+            newContainer {
+              name = "$serviceName-service"
+              image = "gcr.io/fkorotkov/$serviceName-service:latest"
+              volumeMounts = listOf(
+                newVolumeMount {
+                  name = "gcp-credentials"
+                  mountPath = "/etc/credentials"
+                  readOnly = true
+                }
+              )
+              env = listOf(
+                newEnvVar {
+                  name = "GOOGLE_APPLICATION_CREDENTIALS"
+                  value = "/etc/credentials/service-account-credentials.json"
+                }
+              )
+              ports = listOf(
+                newContainerPort {
+                  containerPort = 8080
+                }
+              )
+              livenessProbe {
+                httpGet {
+                  path = "/healthz"
+                  port = IntOrString(8080)
+                }
+                periodSeconds = 60
+              }
+              readinessProbe {
+                httpGet {
+                  path = "/healthz"
+                  port = IntOrString(8080)
+                }
+                initialDelaySeconds = 10
+                periodSeconds = 60
+              }
+            }
+          )
+          volumes = listOf(
+            newVolume {
+              name = "gcp-credentials"
+              secret {
+                secretName = "gcp-credentials"
+              }
+            }
+          )
+        }
+      }
+    }
+  }
+}

--- a/example/src/main/kotlin/example.kt
+++ b/example/src/main/kotlin/example.kt
@@ -6,7 +6,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient
 fun main(args: Array<String>) {
   val client = DefaultKubernetesClient().inNamespace("default")
   client.extensions().ingresses().createOrReplace(
-    ingress {
+    newIngress {
       metadata {
         name = "example-ingress"
       }

--- a/generator/src/main/kotlin/com/fkorotkov/kotlin/dsl/ClassBuilderGenerator.kt
+++ b/generator/src/main/kotlin/com/fkorotkov/kotlin/dsl/ClassBuilderGenerator.kt
@@ -39,7 +39,7 @@ allClasses.map { classBuilderTemplate(it) }.joinToString("\n")
 
   private fun classBuilderTemplate(clazz: KClass<*>): String {
     return """
-fun ${clazz.simpleName?.smartDecapitalize()}(block : ${clazz.simpleName}.() -> Unit = {}): ${clazz.simpleName} {
+fun new${clazz.simpleName}(block : ${clazz.simpleName}.() -> Unit = {}): ${clazz.simpleName} {
   val instance = ${clazz.simpleName}()
   instance.block()
   return instance
@@ -47,11 +47,4 @@ fun ${clazz.simpleName?.smartDecapitalize()}(block : ${clazz.simpleName}.() -> U
 """
   }
 
-  private fun String.smartDecapitalize(): String {
-    return if (isNotEmpty() && this[0].isUpperCase()) {
-      val upperCasePrefixLength = takeWhile(Char::isUpperCase).length
-      val abbreviationLength = Integer.max(1, upperCasePrefixLength - 1)
-      substring(0, abbreviationLength).toLowerCase() + substring(abbreviationLength)
-    } else this
-  }
 }

--- a/kubernetes/dsl/src/main/kotlin-gen/com/fkorotkov/kubernetes/ClassBuilders.kt
+++ b/kubernetes/dsl/src/main/kotlin-gen/com/fkorotkov/kubernetes/ClassBuilders.kt
@@ -272,1883 +272,1883 @@ import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetSpec
 import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetStatus
 
 
-fun awsElasticBlockStoreVolumeSource(block : AWSElasticBlockStoreVolumeSource.() -> Unit = {}): AWSElasticBlockStoreVolumeSource {
+fun newAWSElasticBlockStoreVolumeSource(block : AWSElasticBlockStoreVolumeSource.() -> Unit = {}): AWSElasticBlockStoreVolumeSource {
   val instance = AWSElasticBlockStoreVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun affinity(block : Affinity.() -> Unit = {}): Affinity {
+fun newAffinity(block : Affinity.() -> Unit = {}): Affinity {
   val instance = Affinity()
   instance.block()
   return instance
 }
 
 
-fun attachedVolume(block : AttachedVolume.() -> Unit = {}): AttachedVolume {
+fun newAttachedVolume(block : AttachedVolume.() -> Unit = {}): AttachedVolume {
   val instance = AttachedVolume()
   instance.block()
   return instance
 }
 
 
-fun authInfo(block : AuthInfo.() -> Unit = {}): AuthInfo {
+fun newAuthInfo(block : AuthInfo.() -> Unit = {}): AuthInfo {
   val instance = AuthInfo()
   instance.block()
   return instance
 }
 
 
-fun authProviderConfig(block : AuthProviderConfig.() -> Unit = {}): AuthProviderConfig {
+fun newAuthProviderConfig(block : AuthProviderConfig.() -> Unit = {}): AuthProviderConfig {
   val instance = AuthProviderConfig()
   instance.block()
   return instance
 }
 
 
-fun azureDiskVolumeSource(block : AzureDiskVolumeSource.() -> Unit = {}): AzureDiskVolumeSource {
+fun newAzureDiskVolumeSource(block : AzureDiskVolumeSource.() -> Unit = {}): AzureDiskVolumeSource {
   val instance = AzureDiskVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun azureFileVolumeSource(block : AzureFileVolumeSource.() -> Unit = {}): AzureFileVolumeSource {
+fun newAzureFileVolumeSource(block : AzureFileVolumeSource.() -> Unit = {}): AzureFileVolumeSource {
   val instance = AzureFileVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun baseKubernetesList(block : BaseKubernetesList.() -> Unit = {}): BaseKubernetesList {
+fun newBaseKubernetesList(block : BaseKubernetesList.() -> Unit = {}): BaseKubernetesList {
   val instance = BaseKubernetesList()
   instance.block()
   return instance
 }
 
 
-fun binding(block : Binding.() -> Unit = {}): Binding {
+fun newBinding(block : Binding.() -> Unit = {}): Binding {
   val instance = Binding()
   instance.block()
   return instance
 }
 
 
-fun capabilities(block : Capabilities.() -> Unit = {}): Capabilities {
+fun newCapabilities(block : Capabilities.() -> Unit = {}): Capabilities {
   val instance = Capabilities()
   instance.block()
   return instance
 }
 
 
-fun cephFSVolumeSource(block : CephFSVolumeSource.() -> Unit = {}): CephFSVolumeSource {
+fun newCephFSVolumeSource(block : CephFSVolumeSource.() -> Unit = {}): CephFSVolumeSource {
   val instance = CephFSVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun cinderVolumeSource(block : CinderVolumeSource.() -> Unit = {}): CinderVolumeSource {
+fun newCinderVolumeSource(block : CinderVolumeSource.() -> Unit = {}): CinderVolumeSource {
   val instance = CinderVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun cluster(block : Cluster.() -> Unit = {}): Cluster {
+fun newCluster(block : Cluster.() -> Unit = {}): Cluster {
   val instance = Cluster()
   instance.block()
   return instance
 }
 
 
-fun componentCondition(block : ComponentCondition.() -> Unit = {}): ComponentCondition {
+fun newComponentCondition(block : ComponentCondition.() -> Unit = {}): ComponentCondition {
   val instance = ComponentCondition()
   instance.block()
   return instance
 }
 
 
-fun componentStatus(block : ComponentStatus.() -> Unit = {}): ComponentStatus {
+fun newComponentStatus(block : ComponentStatus.() -> Unit = {}): ComponentStatus {
   val instance = ComponentStatus()
   instance.block()
   return instance
 }
 
 
-fun componentStatusList(block : ComponentStatusList.() -> Unit = {}): ComponentStatusList {
+fun newComponentStatusList(block : ComponentStatusList.() -> Unit = {}): ComponentStatusList {
   val instance = ComponentStatusList()
   instance.block()
   return instance
 }
 
 
-fun config(block : Config.() -> Unit = {}): Config {
+fun newConfig(block : Config.() -> Unit = {}): Config {
   val instance = Config()
   instance.block()
   return instance
 }
 
 
-fun configMap(block : ConfigMap.() -> Unit = {}): ConfigMap {
+fun newConfigMap(block : ConfigMap.() -> Unit = {}): ConfigMap {
   val instance = ConfigMap()
   instance.block()
   return instance
 }
 
 
-fun configMapEnvSource(block : ConfigMapEnvSource.() -> Unit = {}): ConfigMapEnvSource {
+fun newConfigMapEnvSource(block : ConfigMapEnvSource.() -> Unit = {}): ConfigMapEnvSource {
   val instance = ConfigMapEnvSource()
   instance.block()
   return instance
 }
 
 
-fun configMapKeySelector(block : ConfigMapKeySelector.() -> Unit = {}): ConfigMapKeySelector {
+fun newConfigMapKeySelector(block : ConfigMapKeySelector.() -> Unit = {}): ConfigMapKeySelector {
   val instance = ConfigMapKeySelector()
   instance.block()
   return instance
 }
 
 
-fun configMapList(block : ConfigMapList.() -> Unit = {}): ConfigMapList {
+fun newConfigMapList(block : ConfigMapList.() -> Unit = {}): ConfigMapList {
   val instance = ConfigMapList()
   instance.block()
   return instance
 }
 
 
-fun configMapProjection(block : ConfigMapProjection.() -> Unit = {}): ConfigMapProjection {
+fun newConfigMapProjection(block : ConfigMapProjection.() -> Unit = {}): ConfigMapProjection {
   val instance = ConfigMapProjection()
   instance.block()
   return instance
 }
 
 
-fun configMapVolumeSource(block : ConfigMapVolumeSource.() -> Unit = {}): ConfigMapVolumeSource {
+fun newConfigMapVolumeSource(block : ConfigMapVolumeSource.() -> Unit = {}): ConfigMapVolumeSource {
   val instance = ConfigMapVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun container(block : Container.() -> Unit = {}): Container {
+fun newContainer(block : Container.() -> Unit = {}): Container {
   val instance = Container()
   instance.block()
   return instance
 }
 
 
-fun containerImage(block : ContainerImage.() -> Unit = {}): ContainerImage {
+fun newContainerImage(block : ContainerImage.() -> Unit = {}): ContainerImage {
   val instance = ContainerImage()
   instance.block()
   return instance
 }
 
 
-fun containerPort(block : ContainerPort.() -> Unit = {}): ContainerPort {
+fun newContainerPort(block : ContainerPort.() -> Unit = {}): ContainerPort {
   val instance = ContainerPort()
   instance.block()
   return instance
 }
 
 
-fun containerState(block : ContainerState.() -> Unit = {}): ContainerState {
+fun newContainerState(block : ContainerState.() -> Unit = {}): ContainerState {
   val instance = ContainerState()
   instance.block()
   return instance
 }
 
 
-fun containerStateRunning(block : ContainerStateRunning.() -> Unit = {}): ContainerStateRunning {
+fun newContainerStateRunning(block : ContainerStateRunning.() -> Unit = {}): ContainerStateRunning {
   val instance = ContainerStateRunning()
   instance.block()
   return instance
 }
 
 
-fun containerStateTerminated(block : ContainerStateTerminated.() -> Unit = {}): ContainerStateTerminated {
+fun newContainerStateTerminated(block : ContainerStateTerminated.() -> Unit = {}): ContainerStateTerminated {
   val instance = ContainerStateTerminated()
   instance.block()
   return instance
 }
 
 
-fun containerStateWaiting(block : ContainerStateWaiting.() -> Unit = {}): ContainerStateWaiting {
+fun newContainerStateWaiting(block : ContainerStateWaiting.() -> Unit = {}): ContainerStateWaiting {
   val instance = ContainerStateWaiting()
   instance.block()
   return instance
 }
 
 
-fun containerStatus(block : ContainerStatus.() -> Unit = {}): ContainerStatus {
+fun newContainerStatus(block : ContainerStatus.() -> Unit = {}): ContainerStatus {
   val instance = ContainerStatus()
   instance.block()
   return instance
 }
 
 
-fun context(block : Context.() -> Unit = {}): Context {
+fun newContext(block : Context.() -> Unit = {}): Context {
   val instance = Context()
   instance.block()
   return instance
 }
 
 
-fun cronJob(block : CronJob.() -> Unit = {}): CronJob {
+fun newCronJob(block : CronJob.() -> Unit = {}): CronJob {
   val instance = CronJob()
   instance.block()
   return instance
 }
 
 
-fun cronJobList(block : CronJobList.() -> Unit = {}): CronJobList {
+fun newCronJobList(block : CronJobList.() -> Unit = {}): CronJobList {
   val instance = CronJobList()
   instance.block()
   return instance
 }
 
 
-fun cronJobSpec(block : CronJobSpec.() -> Unit = {}): CronJobSpec {
+fun newCronJobSpec(block : CronJobSpec.() -> Unit = {}): CronJobSpec {
   val instance = CronJobSpec()
   instance.block()
   return instance
 }
 
 
-fun cronJobStatus(block : CronJobStatus.() -> Unit = {}): CronJobStatus {
+fun newCronJobStatus(block : CronJobStatus.() -> Unit = {}): CronJobStatus {
   val instance = CronJobStatus()
   instance.block()
   return instance
 }
 
 
-fun crossVersionObjectReference(block : CrossVersionObjectReference.() -> Unit = {}): CrossVersionObjectReference {
+fun newCrossVersionObjectReference(block : CrossVersionObjectReference.() -> Unit = {}): CrossVersionObjectReference {
   val instance = CrossVersionObjectReference()
   instance.block()
   return instance
 }
 
 
-fun daemonEndpoint(block : DaemonEndpoint.() -> Unit = {}): DaemonEndpoint {
+fun newDaemonEndpoint(block : DaemonEndpoint.() -> Unit = {}): DaemonEndpoint {
   val instance = DaemonEndpoint()
   instance.block()
   return instance
 }
 
 
-fun deleteOptions(block : DeleteOptions.() -> Unit = {}): DeleteOptions {
+fun newDeleteOptions(block : DeleteOptions.() -> Unit = {}): DeleteOptions {
   val instance = DeleteOptions()
   instance.block()
   return instance
 }
 
 
-fun downwardAPIProjection(block : DownwardAPIProjection.() -> Unit = {}): DownwardAPIProjection {
+fun newDownwardAPIProjection(block : DownwardAPIProjection.() -> Unit = {}): DownwardAPIProjection {
   val instance = DownwardAPIProjection()
   instance.block()
   return instance
 }
 
 
-fun downwardAPIVolumeFile(block : DownwardAPIVolumeFile.() -> Unit = {}): DownwardAPIVolumeFile {
+fun newDownwardAPIVolumeFile(block : DownwardAPIVolumeFile.() -> Unit = {}): DownwardAPIVolumeFile {
   val instance = DownwardAPIVolumeFile()
   instance.block()
   return instance
 }
 
 
-fun downwardAPIVolumeSource(block : DownwardAPIVolumeSource.() -> Unit = {}): DownwardAPIVolumeSource {
+fun newDownwardAPIVolumeSource(block : DownwardAPIVolumeSource.() -> Unit = {}): DownwardAPIVolumeSource {
   val instance = DownwardAPIVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun emptyDirVolumeSource(block : EmptyDirVolumeSource.() -> Unit = {}): EmptyDirVolumeSource {
+fun newEmptyDirVolumeSource(block : EmptyDirVolumeSource.() -> Unit = {}): EmptyDirVolumeSource {
   val instance = EmptyDirVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun endpointAddress(block : EndpointAddress.() -> Unit = {}): EndpointAddress {
+fun newEndpointAddress(block : EndpointAddress.() -> Unit = {}): EndpointAddress {
   val instance = EndpointAddress()
   instance.block()
   return instance
 }
 
 
-fun endpointPort(block : EndpointPort.() -> Unit = {}): EndpointPort {
+fun newEndpointPort(block : EndpointPort.() -> Unit = {}): EndpointPort {
   val instance = EndpointPort()
   instance.block()
   return instance
 }
 
 
-fun endpointSubset(block : EndpointSubset.() -> Unit = {}): EndpointSubset {
+fun newEndpointSubset(block : EndpointSubset.() -> Unit = {}): EndpointSubset {
   val instance = EndpointSubset()
   instance.block()
   return instance
 }
 
 
-fun endpoints(block : Endpoints.() -> Unit = {}): Endpoints {
+fun newEndpoints(block : Endpoints.() -> Unit = {}): Endpoints {
   val instance = Endpoints()
   instance.block()
   return instance
 }
 
 
-fun endpointsList(block : EndpointsList.() -> Unit = {}): EndpointsList {
+fun newEndpointsList(block : EndpointsList.() -> Unit = {}): EndpointsList {
   val instance = EndpointsList()
   instance.block()
   return instance
 }
 
 
-fun envFromSource(block : EnvFromSource.() -> Unit = {}): EnvFromSource {
+fun newEnvFromSource(block : EnvFromSource.() -> Unit = {}): EnvFromSource {
   val instance = EnvFromSource()
   instance.block()
   return instance
 }
 
 
-fun envVar(block : EnvVar.() -> Unit = {}): EnvVar {
+fun newEnvVar(block : EnvVar.() -> Unit = {}): EnvVar {
   val instance = EnvVar()
   instance.block()
   return instance
 }
 
 
-fun envVarSource(block : EnvVarSource.() -> Unit = {}): EnvVarSource {
+fun newEnvVarSource(block : EnvVarSource.() -> Unit = {}): EnvVarSource {
   val instance = EnvVarSource()
   instance.block()
   return instance
 }
 
 
-fun event(block : Event.() -> Unit = {}): Event {
+fun newEvent(block : Event.() -> Unit = {}): Event {
   val instance = Event()
   instance.block()
   return instance
 }
 
 
-fun eventList(block : EventList.() -> Unit = {}): EventList {
+fun newEventList(block : EventList.() -> Unit = {}): EventList {
   val instance = EventList()
   instance.block()
   return instance
 }
 
 
-fun eventSource(block : EventSource.() -> Unit = {}): EventSource {
+fun newEventSource(block : EventSource.() -> Unit = {}): EventSource {
   val instance = EventSource()
   instance.block()
   return instance
 }
 
 
-fun execAction(block : ExecAction.() -> Unit = {}): ExecAction {
+fun newExecAction(block : ExecAction.() -> Unit = {}): ExecAction {
   val instance = ExecAction()
   instance.block()
   return instance
 }
 
 
-fun fcVolumeSource(block : FCVolumeSource.() -> Unit = {}): FCVolumeSource {
+fun newFCVolumeSource(block : FCVolumeSource.() -> Unit = {}): FCVolumeSource {
   val instance = FCVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun flexVolumeSource(block : FlexVolumeSource.() -> Unit = {}): FlexVolumeSource {
+fun newFlexVolumeSource(block : FlexVolumeSource.() -> Unit = {}): FlexVolumeSource {
   val instance = FlexVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun flockerVolumeSource(block : FlockerVolumeSource.() -> Unit = {}): FlockerVolumeSource {
+fun newFlockerVolumeSource(block : FlockerVolumeSource.() -> Unit = {}): FlockerVolumeSource {
   val instance = FlockerVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun gcePersistentDiskVolumeSource(block : GCEPersistentDiskVolumeSource.() -> Unit = {}): GCEPersistentDiskVolumeSource {
+fun newGCEPersistentDiskVolumeSource(block : GCEPersistentDiskVolumeSource.() -> Unit = {}): GCEPersistentDiskVolumeSource {
   val instance = GCEPersistentDiskVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun gitRepoVolumeSource(block : GitRepoVolumeSource.() -> Unit = {}): GitRepoVolumeSource {
+fun newGitRepoVolumeSource(block : GitRepoVolumeSource.() -> Unit = {}): GitRepoVolumeSource {
   val instance = GitRepoVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun glusterfsVolumeSource(block : GlusterfsVolumeSource.() -> Unit = {}): GlusterfsVolumeSource {
+fun newGlusterfsVolumeSource(block : GlusterfsVolumeSource.() -> Unit = {}): GlusterfsVolumeSource {
   val instance = GlusterfsVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun httpGetAction(block : HTTPGetAction.() -> Unit = {}): HTTPGetAction {
+fun newHTTPGetAction(block : HTTPGetAction.() -> Unit = {}): HTTPGetAction {
   val instance = HTTPGetAction()
   instance.block()
   return instance
 }
 
 
-fun httpHeader(block : HTTPHeader.() -> Unit = {}): HTTPHeader {
+fun newHTTPHeader(block : HTTPHeader.() -> Unit = {}): HTTPHeader {
   val instance = HTTPHeader()
   instance.block()
   return instance
 }
 
 
-fun handler(block : Handler.() -> Unit = {}): Handler {
+fun newHandler(block : Handler.() -> Unit = {}): Handler {
   val instance = Handler()
   instance.block()
   return instance
 }
 
 
-fun horizontalPodAutoscaler(block : HorizontalPodAutoscaler.() -> Unit = {}): HorizontalPodAutoscaler {
+fun newHorizontalPodAutoscaler(block : HorizontalPodAutoscaler.() -> Unit = {}): HorizontalPodAutoscaler {
   val instance = HorizontalPodAutoscaler()
   instance.block()
   return instance
 }
 
 
-fun horizontalPodAutoscalerList(block : HorizontalPodAutoscalerList.() -> Unit = {}): HorizontalPodAutoscalerList {
+fun newHorizontalPodAutoscalerList(block : HorizontalPodAutoscalerList.() -> Unit = {}): HorizontalPodAutoscalerList {
   val instance = HorizontalPodAutoscalerList()
   instance.block()
   return instance
 }
 
 
-fun horizontalPodAutoscalerSpec(block : HorizontalPodAutoscalerSpec.() -> Unit = {}): HorizontalPodAutoscalerSpec {
+fun newHorizontalPodAutoscalerSpec(block : HorizontalPodAutoscalerSpec.() -> Unit = {}): HorizontalPodAutoscalerSpec {
   val instance = HorizontalPodAutoscalerSpec()
   instance.block()
   return instance
 }
 
 
-fun horizontalPodAutoscalerStatus(block : HorizontalPodAutoscalerStatus.() -> Unit = {}): HorizontalPodAutoscalerStatus {
+fun newHorizontalPodAutoscalerStatus(block : HorizontalPodAutoscalerStatus.() -> Unit = {}): HorizontalPodAutoscalerStatus {
   val instance = HorizontalPodAutoscalerStatus()
   instance.block()
   return instance
 }
 
 
-fun hostAlias(block : HostAlias.() -> Unit = {}): HostAlias {
+fun newHostAlias(block : HostAlias.() -> Unit = {}): HostAlias {
   val instance = HostAlias()
   instance.block()
   return instance
 }
 
 
-fun hostPathVolumeSource(block : HostPathVolumeSource.() -> Unit = {}): HostPathVolumeSource {
+fun newHostPathVolumeSource(block : HostPathVolumeSource.() -> Unit = {}): HostPathVolumeSource {
   val instance = HostPathVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun iscsiVolumeSource(block : ISCSIVolumeSource.() -> Unit = {}): ISCSIVolumeSource {
+fun newISCSIVolumeSource(block : ISCSIVolumeSource.() -> Unit = {}): ISCSIVolumeSource {
   val instance = ISCSIVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun initializer(block : Initializer.() -> Unit = {}): Initializer {
+fun newInitializer(block : Initializer.() -> Unit = {}): Initializer {
   val instance = Initializer()
   instance.block()
   return instance
 }
 
 
-fun initializers(block : Initializers.() -> Unit = {}): Initializers {
+fun newInitializers(block : Initializers.() -> Unit = {}): Initializers {
   val instance = Initializers()
   instance.block()
   return instance
 }
 
 
-fun job(block : Job.() -> Unit = {}): Job {
+fun newJob(block : Job.() -> Unit = {}): Job {
   val instance = Job()
   instance.block()
   return instance
 }
 
 
-fun jobCondition(block : JobCondition.() -> Unit = {}): JobCondition {
+fun newJobCondition(block : JobCondition.() -> Unit = {}): JobCondition {
   val instance = JobCondition()
   instance.block()
   return instance
 }
 
 
-fun jobList(block : JobList.() -> Unit = {}): JobList {
+fun newJobList(block : JobList.() -> Unit = {}): JobList {
   val instance = JobList()
   instance.block()
   return instance
 }
 
 
-fun jobSpec(block : JobSpec.() -> Unit = {}): JobSpec {
+fun newJobSpec(block : JobSpec.() -> Unit = {}): JobSpec {
   val instance = JobSpec()
   instance.block()
   return instance
 }
 
 
-fun jobStatus(block : JobStatus.() -> Unit = {}): JobStatus {
+fun newJobStatus(block : JobStatus.() -> Unit = {}): JobStatus {
   val instance = JobStatus()
   instance.block()
   return instance
 }
 
 
-fun jobTemplateSpec(block : JobTemplateSpec.() -> Unit = {}): JobTemplateSpec {
+fun newJobTemplateSpec(block : JobTemplateSpec.() -> Unit = {}): JobTemplateSpec {
   val instance = JobTemplateSpec()
   instance.block()
   return instance
 }
 
 
-fun keyToPath(block : KeyToPath.() -> Unit = {}): KeyToPath {
+fun newKeyToPath(block : KeyToPath.() -> Unit = {}): KeyToPath {
   val instance = KeyToPath()
   instance.block()
   return instance
 }
 
 
-fun kubernetesList(block : KubernetesList.() -> Unit = {}): KubernetesList {
+fun newKubernetesList(block : KubernetesList.() -> Unit = {}): KubernetesList {
   val instance = KubernetesList()
   instance.block()
   return instance
 }
 
 
-fun labelSelector(block : LabelSelector.() -> Unit = {}): LabelSelector {
+fun newLabelSelector(block : LabelSelector.() -> Unit = {}): LabelSelector {
   val instance = LabelSelector()
   instance.block()
   return instance
 }
 
 
-fun labelSelectorRequirement(block : LabelSelectorRequirement.() -> Unit = {}): LabelSelectorRequirement {
+fun newLabelSelectorRequirement(block : LabelSelectorRequirement.() -> Unit = {}): LabelSelectorRequirement {
   val instance = LabelSelectorRequirement()
   instance.block()
   return instance
 }
 
 
-fun lifecycle(block : Lifecycle.() -> Unit = {}): Lifecycle {
+fun newLifecycle(block : Lifecycle.() -> Unit = {}): Lifecycle {
   val instance = Lifecycle()
   instance.block()
   return instance
 }
 
 
-fun limitRange(block : LimitRange.() -> Unit = {}): LimitRange {
+fun newLimitRange(block : LimitRange.() -> Unit = {}): LimitRange {
   val instance = LimitRange()
   instance.block()
   return instance
 }
 
 
-fun limitRangeItem(block : LimitRangeItem.() -> Unit = {}): LimitRangeItem {
+fun newLimitRangeItem(block : LimitRangeItem.() -> Unit = {}): LimitRangeItem {
   val instance = LimitRangeItem()
   instance.block()
   return instance
 }
 
 
-fun limitRangeList(block : LimitRangeList.() -> Unit = {}): LimitRangeList {
+fun newLimitRangeList(block : LimitRangeList.() -> Unit = {}): LimitRangeList {
   val instance = LimitRangeList()
   instance.block()
   return instance
 }
 
 
-fun limitRangeSpec(block : LimitRangeSpec.() -> Unit = {}): LimitRangeSpec {
+fun newLimitRangeSpec(block : LimitRangeSpec.() -> Unit = {}): LimitRangeSpec {
   val instance = LimitRangeSpec()
   instance.block()
   return instance
 }
 
 
-fun listMeta(block : ListMeta.() -> Unit = {}): ListMeta {
+fun newListMeta(block : ListMeta.() -> Unit = {}): ListMeta {
   val instance = ListMeta()
   instance.block()
   return instance
 }
 
 
-fun loadBalancerIngress(block : LoadBalancerIngress.() -> Unit = {}): LoadBalancerIngress {
+fun newLoadBalancerIngress(block : LoadBalancerIngress.() -> Unit = {}): LoadBalancerIngress {
   val instance = LoadBalancerIngress()
   instance.block()
   return instance
 }
 
 
-fun loadBalancerStatus(block : LoadBalancerStatus.() -> Unit = {}): LoadBalancerStatus {
+fun newLoadBalancerStatus(block : LoadBalancerStatus.() -> Unit = {}): LoadBalancerStatus {
   val instance = LoadBalancerStatus()
   instance.block()
   return instance
 }
 
 
-fun localObjectReference(block : LocalObjectReference.() -> Unit = {}): LocalObjectReference {
+fun newLocalObjectReference(block : LocalObjectReference.() -> Unit = {}): LocalObjectReference {
   val instance = LocalObjectReference()
   instance.block()
   return instance
 }
 
 
-fun localVolumeSource(block : LocalVolumeSource.() -> Unit = {}): LocalVolumeSource {
+fun newLocalVolumeSource(block : LocalVolumeSource.() -> Unit = {}): LocalVolumeSource {
   val instance = LocalVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun nfsVolumeSource(block : NFSVolumeSource.() -> Unit = {}): NFSVolumeSource {
+fun newNFSVolumeSource(block : NFSVolumeSource.() -> Unit = {}): NFSVolumeSource {
   val instance = NFSVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun namedAuthInfo(block : NamedAuthInfo.() -> Unit = {}): NamedAuthInfo {
+fun newNamedAuthInfo(block : NamedAuthInfo.() -> Unit = {}): NamedAuthInfo {
   val instance = NamedAuthInfo()
   instance.block()
   return instance
 }
 
 
-fun namedCluster(block : NamedCluster.() -> Unit = {}): NamedCluster {
+fun newNamedCluster(block : NamedCluster.() -> Unit = {}): NamedCluster {
   val instance = NamedCluster()
   instance.block()
   return instance
 }
 
 
-fun namedContext(block : NamedContext.() -> Unit = {}): NamedContext {
+fun newNamedContext(block : NamedContext.() -> Unit = {}): NamedContext {
   val instance = NamedContext()
   instance.block()
   return instance
 }
 
 
-fun namedExtension(block : NamedExtension.() -> Unit = {}): NamedExtension {
+fun newNamedExtension(block : NamedExtension.() -> Unit = {}): NamedExtension {
   val instance = NamedExtension()
   instance.block()
   return instance
 }
 
 
-fun namespace(block : Namespace.() -> Unit = {}): Namespace {
+fun newNamespace(block : Namespace.() -> Unit = {}): Namespace {
   val instance = Namespace()
   instance.block()
   return instance
 }
 
 
-fun namespaceList(block : NamespaceList.() -> Unit = {}): NamespaceList {
+fun newNamespaceList(block : NamespaceList.() -> Unit = {}): NamespaceList {
   val instance = NamespaceList()
   instance.block()
   return instance
 }
 
 
-fun namespaceSpec(block : NamespaceSpec.() -> Unit = {}): NamespaceSpec {
+fun newNamespaceSpec(block : NamespaceSpec.() -> Unit = {}): NamespaceSpec {
   val instance = NamespaceSpec()
   instance.block()
   return instance
 }
 
 
-fun namespaceStatus(block : NamespaceStatus.() -> Unit = {}): NamespaceStatus {
+fun newNamespaceStatus(block : NamespaceStatus.() -> Unit = {}): NamespaceStatus {
   val instance = NamespaceStatus()
   instance.block()
   return instance
 }
 
 
-fun node(block : Node.() -> Unit = {}): Node {
+fun newNode(block : Node.() -> Unit = {}): Node {
   val instance = Node()
   instance.block()
   return instance
 }
 
 
-fun nodeAddress(block : NodeAddress.() -> Unit = {}): NodeAddress {
+fun newNodeAddress(block : NodeAddress.() -> Unit = {}): NodeAddress {
   val instance = NodeAddress()
   instance.block()
   return instance
 }
 
 
-fun nodeAffinity(block : NodeAffinity.() -> Unit = {}): NodeAffinity {
+fun newNodeAffinity(block : NodeAffinity.() -> Unit = {}): NodeAffinity {
   val instance = NodeAffinity()
   instance.block()
   return instance
 }
 
 
-fun nodeCondition(block : NodeCondition.() -> Unit = {}): NodeCondition {
+fun newNodeCondition(block : NodeCondition.() -> Unit = {}): NodeCondition {
   val instance = NodeCondition()
   instance.block()
   return instance
 }
 
 
-fun nodeDaemonEndpoints(block : NodeDaemonEndpoints.() -> Unit = {}): NodeDaemonEndpoints {
+fun newNodeDaemonEndpoints(block : NodeDaemonEndpoints.() -> Unit = {}): NodeDaemonEndpoints {
   val instance = NodeDaemonEndpoints()
   instance.block()
   return instance
 }
 
 
-fun nodeList(block : NodeList.() -> Unit = {}): NodeList {
+fun newNodeList(block : NodeList.() -> Unit = {}): NodeList {
   val instance = NodeList()
   instance.block()
   return instance
 }
 
 
-fun nodeSelector(block : NodeSelector.() -> Unit = {}): NodeSelector {
+fun newNodeSelector(block : NodeSelector.() -> Unit = {}): NodeSelector {
   val instance = NodeSelector()
   instance.block()
   return instance
 }
 
 
-fun nodeSelectorRequirement(block : NodeSelectorRequirement.() -> Unit = {}): NodeSelectorRequirement {
+fun newNodeSelectorRequirement(block : NodeSelectorRequirement.() -> Unit = {}): NodeSelectorRequirement {
   val instance = NodeSelectorRequirement()
   instance.block()
   return instance
 }
 
 
-fun nodeSelectorTerm(block : NodeSelectorTerm.() -> Unit = {}): NodeSelectorTerm {
+fun newNodeSelectorTerm(block : NodeSelectorTerm.() -> Unit = {}): NodeSelectorTerm {
   val instance = NodeSelectorTerm()
   instance.block()
   return instance
 }
 
 
-fun nodeSpec(block : NodeSpec.() -> Unit = {}): NodeSpec {
+fun newNodeSpec(block : NodeSpec.() -> Unit = {}): NodeSpec {
   val instance = NodeSpec()
   instance.block()
   return instance
 }
 
 
-fun nodeStatus(block : NodeStatus.() -> Unit = {}): NodeStatus {
+fun newNodeStatus(block : NodeStatus.() -> Unit = {}): NodeStatus {
   val instance = NodeStatus()
   instance.block()
   return instance
 }
 
 
-fun nodeSystemInfo(block : NodeSystemInfo.() -> Unit = {}): NodeSystemInfo {
+fun newNodeSystemInfo(block : NodeSystemInfo.() -> Unit = {}): NodeSystemInfo {
   val instance = NodeSystemInfo()
   instance.block()
   return instance
 }
 
 
-fun objectFieldSelector(block : ObjectFieldSelector.() -> Unit = {}): ObjectFieldSelector {
+fun newObjectFieldSelector(block : ObjectFieldSelector.() -> Unit = {}): ObjectFieldSelector {
   val instance = ObjectFieldSelector()
   instance.block()
   return instance
 }
 
 
-fun objectMeta(block : ObjectMeta.() -> Unit = {}): ObjectMeta {
+fun newObjectMeta(block : ObjectMeta.() -> Unit = {}): ObjectMeta {
   val instance = ObjectMeta()
   instance.block()
   return instance
 }
 
 
-fun objectReference(block : ObjectReference.() -> Unit = {}): ObjectReference {
+fun newObjectReference(block : ObjectReference.() -> Unit = {}): ObjectReference {
   val instance = ObjectReference()
   instance.block()
   return instance
 }
 
 
-fun ownerReference(block : OwnerReference.() -> Unit = {}): OwnerReference {
+fun newOwnerReference(block : OwnerReference.() -> Unit = {}): OwnerReference {
   val instance = OwnerReference()
   instance.block()
   return instance
 }
 
 
-fun patch(block : Patch.() -> Unit = {}): Patch {
+fun newPatch(block : Patch.() -> Unit = {}): Patch {
   val instance = Patch()
   instance.block()
   return instance
 }
 
 
-fun persistentVolume(block : PersistentVolume.() -> Unit = {}): PersistentVolume {
+fun newPersistentVolume(block : PersistentVolume.() -> Unit = {}): PersistentVolume {
   val instance = PersistentVolume()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeClaim(block : PersistentVolumeClaim.() -> Unit = {}): PersistentVolumeClaim {
+fun newPersistentVolumeClaim(block : PersistentVolumeClaim.() -> Unit = {}): PersistentVolumeClaim {
   val instance = PersistentVolumeClaim()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeClaimList(block : PersistentVolumeClaimList.() -> Unit = {}): PersistentVolumeClaimList {
+fun newPersistentVolumeClaimList(block : PersistentVolumeClaimList.() -> Unit = {}): PersistentVolumeClaimList {
   val instance = PersistentVolumeClaimList()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeClaimSpec(block : PersistentVolumeClaimSpec.() -> Unit = {}): PersistentVolumeClaimSpec {
+fun newPersistentVolumeClaimSpec(block : PersistentVolumeClaimSpec.() -> Unit = {}): PersistentVolumeClaimSpec {
   val instance = PersistentVolumeClaimSpec()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeClaimStatus(block : PersistentVolumeClaimStatus.() -> Unit = {}): PersistentVolumeClaimStatus {
+fun newPersistentVolumeClaimStatus(block : PersistentVolumeClaimStatus.() -> Unit = {}): PersistentVolumeClaimStatus {
   val instance = PersistentVolumeClaimStatus()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeClaimVolumeSource(block : PersistentVolumeClaimVolumeSource.() -> Unit = {}): PersistentVolumeClaimVolumeSource {
+fun newPersistentVolumeClaimVolumeSource(block : PersistentVolumeClaimVolumeSource.() -> Unit = {}): PersistentVolumeClaimVolumeSource {
   val instance = PersistentVolumeClaimVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeList(block : PersistentVolumeList.() -> Unit = {}): PersistentVolumeList {
+fun newPersistentVolumeList(block : PersistentVolumeList.() -> Unit = {}): PersistentVolumeList {
   val instance = PersistentVolumeList()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeSpec(block : PersistentVolumeSpec.() -> Unit = {}): PersistentVolumeSpec {
+fun newPersistentVolumeSpec(block : PersistentVolumeSpec.() -> Unit = {}): PersistentVolumeSpec {
   val instance = PersistentVolumeSpec()
   instance.block()
   return instance
 }
 
 
-fun persistentVolumeStatus(block : PersistentVolumeStatus.() -> Unit = {}): PersistentVolumeStatus {
+fun newPersistentVolumeStatus(block : PersistentVolumeStatus.() -> Unit = {}): PersistentVolumeStatus {
   val instance = PersistentVolumeStatus()
   instance.block()
   return instance
 }
 
 
-fun photonPersistentDiskVolumeSource(block : PhotonPersistentDiskVolumeSource.() -> Unit = {}): PhotonPersistentDiskVolumeSource {
+fun newPhotonPersistentDiskVolumeSource(block : PhotonPersistentDiskVolumeSource.() -> Unit = {}): PhotonPersistentDiskVolumeSource {
   val instance = PhotonPersistentDiskVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun pod(block : Pod.() -> Unit = {}): Pod {
+fun newPod(block : Pod.() -> Unit = {}): Pod {
   val instance = Pod()
   instance.block()
   return instance
 }
 
 
-fun podAffinity(block : PodAffinity.() -> Unit = {}): PodAffinity {
+fun newPodAffinity(block : PodAffinity.() -> Unit = {}): PodAffinity {
   val instance = PodAffinity()
   instance.block()
   return instance
 }
 
 
-fun podAffinityTerm(block : PodAffinityTerm.() -> Unit = {}): PodAffinityTerm {
+fun newPodAffinityTerm(block : PodAffinityTerm.() -> Unit = {}): PodAffinityTerm {
   val instance = PodAffinityTerm()
   instance.block()
   return instance
 }
 
 
-fun podAntiAffinity(block : PodAntiAffinity.() -> Unit = {}): PodAntiAffinity {
+fun newPodAntiAffinity(block : PodAntiAffinity.() -> Unit = {}): PodAntiAffinity {
   val instance = PodAntiAffinity()
   instance.block()
   return instance
 }
 
 
-fun podCondition(block : PodCondition.() -> Unit = {}): PodCondition {
+fun newPodCondition(block : PodCondition.() -> Unit = {}): PodCondition {
   val instance = PodCondition()
   instance.block()
   return instance
 }
 
 
-fun podList(block : PodList.() -> Unit = {}): PodList {
+fun newPodList(block : PodList.() -> Unit = {}): PodList {
   val instance = PodList()
   instance.block()
   return instance
 }
 
 
-fun podSecurityContext(block : PodSecurityContext.() -> Unit = {}): PodSecurityContext {
+fun newPodSecurityContext(block : PodSecurityContext.() -> Unit = {}): PodSecurityContext {
   val instance = PodSecurityContext()
   instance.block()
   return instance
 }
 
 
-fun podSpec(block : PodSpec.() -> Unit = {}): PodSpec {
+fun newPodSpec(block : PodSpec.() -> Unit = {}): PodSpec {
   val instance = PodSpec()
   instance.block()
   return instance
 }
 
 
-fun podStatus(block : PodStatus.() -> Unit = {}): PodStatus {
+fun newPodStatus(block : PodStatus.() -> Unit = {}): PodStatus {
   val instance = PodStatus()
   instance.block()
   return instance
 }
 
 
-fun podTemplate(block : PodTemplate.() -> Unit = {}): PodTemplate {
+fun newPodTemplate(block : PodTemplate.() -> Unit = {}): PodTemplate {
   val instance = PodTemplate()
   instance.block()
   return instance
 }
 
 
-fun podTemplateList(block : PodTemplateList.() -> Unit = {}): PodTemplateList {
+fun newPodTemplateList(block : PodTemplateList.() -> Unit = {}): PodTemplateList {
   val instance = PodTemplateList()
   instance.block()
   return instance
 }
 
 
-fun podTemplateSpec(block : PodTemplateSpec.() -> Unit = {}): PodTemplateSpec {
+fun newPodTemplateSpec(block : PodTemplateSpec.() -> Unit = {}): PodTemplateSpec {
   val instance = PodTemplateSpec()
   instance.block()
   return instance
 }
 
 
-fun portworxVolumeSource(block : PortworxVolumeSource.() -> Unit = {}): PortworxVolumeSource {
+fun newPortworxVolumeSource(block : PortworxVolumeSource.() -> Unit = {}): PortworxVolumeSource {
   val instance = PortworxVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun preconditions(block : Preconditions.() -> Unit = {}): Preconditions {
+fun newPreconditions(block : Preconditions.() -> Unit = {}): Preconditions {
   val instance = Preconditions()
   instance.block()
   return instance
 }
 
 
-fun preferences(block : Preferences.() -> Unit = {}): Preferences {
+fun newPreferences(block : Preferences.() -> Unit = {}): Preferences {
   val instance = Preferences()
   instance.block()
   return instance
 }
 
 
-fun preferredSchedulingTerm(block : PreferredSchedulingTerm.() -> Unit = {}): PreferredSchedulingTerm {
+fun newPreferredSchedulingTerm(block : PreferredSchedulingTerm.() -> Unit = {}): PreferredSchedulingTerm {
   val instance = PreferredSchedulingTerm()
   instance.block()
   return instance
 }
 
 
-fun probe(block : Probe.() -> Unit = {}): Probe {
+fun newProbe(block : Probe.() -> Unit = {}): Probe {
   val instance = Probe()
   instance.block()
   return instance
 }
 
 
-fun projectedVolumeSource(block : ProjectedVolumeSource.() -> Unit = {}): ProjectedVolumeSource {
+fun newProjectedVolumeSource(block : ProjectedVolumeSource.() -> Unit = {}): ProjectedVolumeSource {
   val instance = ProjectedVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun quobyteVolumeSource(block : QuobyteVolumeSource.() -> Unit = {}): QuobyteVolumeSource {
+fun newQuobyteVolumeSource(block : QuobyteVolumeSource.() -> Unit = {}): QuobyteVolumeSource {
   val instance = QuobyteVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun rbdVolumeSource(block : RBDVolumeSource.() -> Unit = {}): RBDVolumeSource {
+fun newRBDVolumeSource(block : RBDVolumeSource.() -> Unit = {}): RBDVolumeSource {
   val instance = RBDVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun replicationController(block : ReplicationController.() -> Unit = {}): ReplicationController {
+fun newReplicationController(block : ReplicationController.() -> Unit = {}): ReplicationController {
   val instance = ReplicationController()
   instance.block()
   return instance
 }
 
 
-fun replicationControllerCondition(block : ReplicationControllerCondition.() -> Unit = {}): ReplicationControllerCondition {
+fun newReplicationControllerCondition(block : ReplicationControllerCondition.() -> Unit = {}): ReplicationControllerCondition {
   val instance = ReplicationControllerCondition()
   instance.block()
   return instance
 }
 
 
-fun replicationControllerList(block : ReplicationControllerList.() -> Unit = {}): ReplicationControllerList {
+fun newReplicationControllerList(block : ReplicationControllerList.() -> Unit = {}): ReplicationControllerList {
   val instance = ReplicationControllerList()
   instance.block()
   return instance
 }
 
 
-fun replicationControllerSpec(block : ReplicationControllerSpec.() -> Unit = {}): ReplicationControllerSpec {
+fun newReplicationControllerSpec(block : ReplicationControllerSpec.() -> Unit = {}): ReplicationControllerSpec {
   val instance = ReplicationControllerSpec()
   instance.block()
   return instance
 }
 
 
-fun replicationControllerStatus(block : ReplicationControllerStatus.() -> Unit = {}): ReplicationControllerStatus {
+fun newReplicationControllerStatus(block : ReplicationControllerStatus.() -> Unit = {}): ReplicationControllerStatus {
   val instance = ReplicationControllerStatus()
   instance.block()
   return instance
 }
 
 
-fun resourceFieldSelector(block : ResourceFieldSelector.() -> Unit = {}): ResourceFieldSelector {
+fun newResourceFieldSelector(block : ResourceFieldSelector.() -> Unit = {}): ResourceFieldSelector {
   val instance = ResourceFieldSelector()
   instance.block()
   return instance
 }
 
 
-fun resourceQuota(block : ResourceQuota.() -> Unit = {}): ResourceQuota {
+fun newResourceQuota(block : ResourceQuota.() -> Unit = {}): ResourceQuota {
   val instance = ResourceQuota()
   instance.block()
   return instance
 }
 
 
-fun resourceQuotaList(block : ResourceQuotaList.() -> Unit = {}): ResourceQuotaList {
+fun newResourceQuotaList(block : ResourceQuotaList.() -> Unit = {}): ResourceQuotaList {
   val instance = ResourceQuotaList()
   instance.block()
   return instance
 }
 
 
-fun resourceQuotaSpec(block : ResourceQuotaSpec.() -> Unit = {}): ResourceQuotaSpec {
+fun newResourceQuotaSpec(block : ResourceQuotaSpec.() -> Unit = {}): ResourceQuotaSpec {
   val instance = ResourceQuotaSpec()
   instance.block()
   return instance
 }
 
 
-fun resourceQuotaStatus(block : ResourceQuotaStatus.() -> Unit = {}): ResourceQuotaStatus {
+fun newResourceQuotaStatus(block : ResourceQuotaStatus.() -> Unit = {}): ResourceQuotaStatus {
   val instance = ResourceQuotaStatus()
   instance.block()
   return instance
 }
 
 
-fun resourceRequirements(block : ResourceRequirements.() -> Unit = {}): ResourceRequirements {
+fun newResourceRequirements(block : ResourceRequirements.() -> Unit = {}): ResourceRequirements {
   val instance = ResourceRequirements()
   instance.block()
   return instance
 }
 
 
-fun rootPaths(block : RootPaths.() -> Unit = {}): RootPaths {
+fun newRootPaths(block : RootPaths.() -> Unit = {}): RootPaths {
   val instance = RootPaths()
   instance.block()
   return instance
 }
 
 
-fun seLinuxOptions(block : SELinuxOptions.() -> Unit = {}): SELinuxOptions {
+fun newSELinuxOptions(block : SELinuxOptions.() -> Unit = {}): SELinuxOptions {
   val instance = SELinuxOptions()
   instance.block()
   return instance
 }
 
 
-fun scaleIOVolumeSource(block : ScaleIOVolumeSource.() -> Unit = {}): ScaleIOVolumeSource {
+fun newScaleIOVolumeSource(block : ScaleIOVolumeSource.() -> Unit = {}): ScaleIOVolumeSource {
   val instance = ScaleIOVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun secret(block : Secret.() -> Unit = {}): Secret {
+fun newSecret(block : Secret.() -> Unit = {}): Secret {
   val instance = Secret()
   instance.block()
   return instance
 }
 
 
-fun secretEnvSource(block : SecretEnvSource.() -> Unit = {}): SecretEnvSource {
+fun newSecretEnvSource(block : SecretEnvSource.() -> Unit = {}): SecretEnvSource {
   val instance = SecretEnvSource()
   instance.block()
   return instance
 }
 
 
-fun secretKeySelector(block : SecretKeySelector.() -> Unit = {}): SecretKeySelector {
+fun newSecretKeySelector(block : SecretKeySelector.() -> Unit = {}): SecretKeySelector {
   val instance = SecretKeySelector()
   instance.block()
   return instance
 }
 
 
-fun secretList(block : SecretList.() -> Unit = {}): SecretList {
+fun newSecretList(block : SecretList.() -> Unit = {}): SecretList {
   val instance = SecretList()
   instance.block()
   return instance
 }
 
 
-fun secretProjection(block : SecretProjection.() -> Unit = {}): SecretProjection {
+fun newSecretProjection(block : SecretProjection.() -> Unit = {}): SecretProjection {
   val instance = SecretProjection()
   instance.block()
   return instance
 }
 
 
-fun secretVolumeSource(block : SecretVolumeSource.() -> Unit = {}): SecretVolumeSource {
+fun newSecretVolumeSource(block : SecretVolumeSource.() -> Unit = {}): SecretVolumeSource {
   val instance = SecretVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun securityContext(block : SecurityContext.() -> Unit = {}): SecurityContext {
+fun newSecurityContext(block : SecurityContext.() -> Unit = {}): SecurityContext {
   val instance = SecurityContext()
   instance.block()
   return instance
 }
 
 
-fun service(block : Service.() -> Unit = {}): Service {
+fun newService(block : Service.() -> Unit = {}): Service {
   val instance = Service()
   instance.block()
   return instance
 }
 
 
-fun serviceAccount(block : ServiceAccount.() -> Unit = {}): ServiceAccount {
+fun newServiceAccount(block : ServiceAccount.() -> Unit = {}): ServiceAccount {
   val instance = ServiceAccount()
   instance.block()
   return instance
 }
 
 
-fun serviceAccountList(block : ServiceAccountList.() -> Unit = {}): ServiceAccountList {
+fun newServiceAccountList(block : ServiceAccountList.() -> Unit = {}): ServiceAccountList {
   val instance = ServiceAccountList()
   instance.block()
   return instance
 }
 
 
-fun serviceList(block : ServiceList.() -> Unit = {}): ServiceList {
+fun newServiceList(block : ServiceList.() -> Unit = {}): ServiceList {
   val instance = ServiceList()
   instance.block()
   return instance
 }
 
 
-fun servicePort(block : ServicePort.() -> Unit = {}): ServicePort {
+fun newServicePort(block : ServicePort.() -> Unit = {}): ServicePort {
   val instance = ServicePort()
   instance.block()
   return instance
 }
 
 
-fun serviceSpec(block : ServiceSpec.() -> Unit = {}): ServiceSpec {
+fun newServiceSpec(block : ServiceSpec.() -> Unit = {}): ServiceSpec {
   val instance = ServiceSpec()
   instance.block()
   return instance
 }
 
 
-fun serviceStatus(block : ServiceStatus.() -> Unit = {}): ServiceStatus {
+fun newServiceStatus(block : ServiceStatus.() -> Unit = {}): ServiceStatus {
   val instance = ServiceStatus()
   instance.block()
   return instance
 }
 
 
-fun status(block : Status.() -> Unit = {}): Status {
+fun newStatus(block : Status.() -> Unit = {}): Status {
   val instance = Status()
   instance.block()
   return instance
 }
 
 
-fun statusCause(block : StatusCause.() -> Unit = {}): StatusCause {
+fun newStatusCause(block : StatusCause.() -> Unit = {}): StatusCause {
   val instance = StatusCause()
   instance.block()
   return instance
 }
 
 
-fun statusDetails(block : StatusDetails.() -> Unit = {}): StatusDetails {
+fun newStatusDetails(block : StatusDetails.() -> Unit = {}): StatusDetails {
   val instance = StatusDetails()
   instance.block()
   return instance
 }
 
 
-fun storageClass(block : StorageClass.() -> Unit = {}): StorageClass {
+fun newStorageClass(block : StorageClass.() -> Unit = {}): StorageClass {
   val instance = StorageClass()
   instance.block()
   return instance
 }
 
 
-fun storageClassList(block : StorageClassList.() -> Unit = {}): StorageClassList {
+fun newStorageClassList(block : StorageClassList.() -> Unit = {}): StorageClassList {
   val instance = StorageClassList()
   instance.block()
   return instance
 }
 
 
-fun storageOSPersistentVolumeSource(block : StorageOSPersistentVolumeSource.() -> Unit = {}): StorageOSPersistentVolumeSource {
+fun newStorageOSPersistentVolumeSource(block : StorageOSPersistentVolumeSource.() -> Unit = {}): StorageOSPersistentVolumeSource {
   val instance = StorageOSPersistentVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun storageOSVolumeSource(block : StorageOSVolumeSource.() -> Unit = {}): StorageOSVolumeSource {
+fun newStorageOSVolumeSource(block : StorageOSVolumeSource.() -> Unit = {}): StorageOSVolumeSource {
   val instance = StorageOSVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun tcpSocketAction(block : TCPSocketAction.() -> Unit = {}): TCPSocketAction {
+fun newTCPSocketAction(block : TCPSocketAction.() -> Unit = {}): TCPSocketAction {
   val instance = TCPSocketAction()
   instance.block()
   return instance
 }
 
 
-fun taint(block : Taint.() -> Unit = {}): Taint {
+fun newTaint(block : Taint.() -> Unit = {}): Taint {
   val instance = Taint()
   instance.block()
   return instance
 }
 
 
-fun toleration(block : Toleration.() -> Unit = {}): Toleration {
+fun newToleration(block : Toleration.() -> Unit = {}): Toleration {
   val instance = Toleration()
   instance.block()
   return instance
 }
 
 
-fun volume(block : Volume.() -> Unit = {}): Volume {
+fun newVolume(block : Volume.() -> Unit = {}): Volume {
   val instance = Volume()
   instance.block()
   return instance
 }
 
 
-fun volumeMount(block : VolumeMount.() -> Unit = {}): VolumeMount {
+fun newVolumeMount(block : VolumeMount.() -> Unit = {}): VolumeMount {
   val instance = VolumeMount()
   instance.block()
   return instance
 }
 
 
-fun volumeProjection(block : VolumeProjection.() -> Unit = {}): VolumeProjection {
+fun newVolumeProjection(block : VolumeProjection.() -> Unit = {}): VolumeProjection {
   val instance = VolumeProjection()
   instance.block()
   return instance
 }
 
 
-fun vsphereVirtualDiskVolumeSource(block : VsphereVirtualDiskVolumeSource.() -> Unit = {}): VsphereVirtualDiskVolumeSource {
+fun newVsphereVirtualDiskVolumeSource(block : VsphereVirtualDiskVolumeSource.() -> Unit = {}): VsphereVirtualDiskVolumeSource {
   val instance = VsphereVirtualDiskVolumeSource()
   instance.block()
   return instance
 }
 
 
-fun watchEvent(block : WatchEvent.() -> Unit = {}): WatchEvent {
+fun newWatchEvent(block : WatchEvent.() -> Unit = {}): WatchEvent {
   val instance = WatchEvent()
   instance.block()
   return instance
 }
 
 
-fun weightedPodAffinityTerm(block : WeightedPodAffinityTerm.() -> Unit = {}): WeightedPodAffinityTerm {
+fun newWeightedPodAffinityTerm(block : WeightedPodAffinityTerm.() -> Unit = {}): WeightedPodAffinityTerm {
   val instance = WeightedPodAffinityTerm()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinition(block : CustomResourceDefinition.() -> Unit = {}): CustomResourceDefinition {
+fun newCustomResourceDefinition(block : CustomResourceDefinition.() -> Unit = {}): CustomResourceDefinition {
   val instance = CustomResourceDefinition()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinitionCondition(block : CustomResourceDefinitionCondition.() -> Unit = {}): CustomResourceDefinitionCondition {
+fun newCustomResourceDefinitionCondition(block : CustomResourceDefinitionCondition.() -> Unit = {}): CustomResourceDefinitionCondition {
   val instance = CustomResourceDefinitionCondition()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinitionList(block : CustomResourceDefinitionList.() -> Unit = {}): CustomResourceDefinitionList {
+fun newCustomResourceDefinitionList(block : CustomResourceDefinitionList.() -> Unit = {}): CustomResourceDefinitionList {
   val instance = CustomResourceDefinitionList()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinitionNames(block : CustomResourceDefinitionNames.() -> Unit = {}): CustomResourceDefinitionNames {
+fun newCustomResourceDefinitionNames(block : CustomResourceDefinitionNames.() -> Unit = {}): CustomResourceDefinitionNames {
   val instance = CustomResourceDefinitionNames()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinitionSpec(block : CustomResourceDefinitionSpec.() -> Unit = {}): CustomResourceDefinitionSpec {
+fun newCustomResourceDefinitionSpec(block : CustomResourceDefinitionSpec.() -> Unit = {}): CustomResourceDefinitionSpec {
   val instance = CustomResourceDefinitionSpec()
   instance.block()
   return instance
 }
 
 
-fun customResourceDefinitionStatus(block : CustomResourceDefinitionStatus.() -> Unit = {}): CustomResourceDefinitionStatus {
+fun newCustomResourceDefinitionStatus(block : CustomResourceDefinitionStatus.() -> Unit = {}): CustomResourceDefinitionStatus {
   val instance = CustomResourceDefinitionStatus()
   instance.block()
   return instance
 }
 
 
-fun tokenReview(block : TokenReview.() -> Unit = {}): TokenReview {
+fun newTokenReview(block : TokenReview.() -> Unit = {}): TokenReview {
   val instance = TokenReview()
   instance.block()
   return instance
 }
 
 
-fun tokenReviewSpec(block : TokenReviewSpec.() -> Unit = {}): TokenReviewSpec {
+fun newTokenReviewSpec(block : TokenReviewSpec.() -> Unit = {}): TokenReviewSpec {
   val instance = TokenReviewSpec()
   instance.block()
   return instance
 }
 
 
-fun tokenReviewStatus(block : TokenReviewStatus.() -> Unit = {}): TokenReviewStatus {
+fun newTokenReviewStatus(block : TokenReviewStatus.() -> Unit = {}): TokenReviewStatus {
   val instance = TokenReviewStatus()
   instance.block()
   return instance
 }
 
 
-fun userInfo(block : UserInfo.() -> Unit = {}): UserInfo {
+fun newUserInfo(block : UserInfo.() -> Unit = {}): UserInfo {
   val instance = UserInfo()
   instance.block()
   return instance
 }
 
 
-fun localSubjectAccessReview(block : LocalSubjectAccessReview.() -> Unit = {}): LocalSubjectAccessReview {
+fun newLocalSubjectAccessReview(block : LocalSubjectAccessReview.() -> Unit = {}): LocalSubjectAccessReview {
   val instance = LocalSubjectAccessReview()
   instance.block()
   return instance
 }
 
 
-fun nonResourceAttributes(block : NonResourceAttributes.() -> Unit = {}): NonResourceAttributes {
+fun newNonResourceAttributes(block : NonResourceAttributes.() -> Unit = {}): NonResourceAttributes {
   val instance = NonResourceAttributes()
   instance.block()
   return instance
 }
 
 
-fun resourceAttributes(block : ResourceAttributes.() -> Unit = {}): ResourceAttributes {
+fun newResourceAttributes(block : ResourceAttributes.() -> Unit = {}): ResourceAttributes {
   val instance = ResourceAttributes()
   instance.block()
   return instance
 }
 
 
-fun subjectAccessReview(block : SubjectAccessReview.() -> Unit = {}): SubjectAccessReview {
+fun newSubjectAccessReview(block : SubjectAccessReview.() -> Unit = {}): SubjectAccessReview {
   val instance = SubjectAccessReview()
   instance.block()
   return instance
 }
 
 
-fun subjectAccessReviewSpec(block : SubjectAccessReviewSpec.() -> Unit = {}): SubjectAccessReviewSpec {
+fun newSubjectAccessReviewSpec(block : SubjectAccessReviewSpec.() -> Unit = {}): SubjectAccessReviewSpec {
   val instance = SubjectAccessReviewSpec()
   instance.block()
   return instance
 }
 
 
-fun subjectAccessReviewStatus(block : SubjectAccessReviewStatus.() -> Unit = {}): SubjectAccessReviewStatus {
+fun newSubjectAccessReviewStatus(block : SubjectAccessReviewStatus.() -> Unit = {}): SubjectAccessReviewStatus {
   val instance = SubjectAccessReviewStatus()
   instance.block()
   return instance
 }
 
 
-fun apiVersion(block : APIVersion.() -> Unit = {}): APIVersion {
+fun newAPIVersion(block : APIVersion.() -> Unit = {}): APIVersion {
   val instance = APIVersion()
   instance.block()
   return instance
 }
 
 
-fun daemonSet(block : DaemonSet.() -> Unit = {}): DaemonSet {
+fun newDaemonSet(block : DaemonSet.() -> Unit = {}): DaemonSet {
   val instance = DaemonSet()
   instance.block()
   return instance
 }
 
 
-fun daemonSetList(block : DaemonSetList.() -> Unit = {}): DaemonSetList {
+fun newDaemonSetList(block : DaemonSetList.() -> Unit = {}): DaemonSetList {
   val instance = DaemonSetList()
   instance.block()
   return instance
 }
 
 
-fun daemonSetSpec(block : DaemonSetSpec.() -> Unit = {}): DaemonSetSpec {
+fun newDaemonSetSpec(block : DaemonSetSpec.() -> Unit = {}): DaemonSetSpec {
   val instance = DaemonSetSpec()
   instance.block()
   return instance
 }
 
 
-fun daemonSetStatus(block : DaemonSetStatus.() -> Unit = {}): DaemonSetStatus {
+fun newDaemonSetStatus(block : DaemonSetStatus.() -> Unit = {}): DaemonSetStatus {
   val instance = DaemonSetStatus()
   instance.block()
   return instance
 }
 
 
-fun daemonSetUpdateStrategy(block : DaemonSetUpdateStrategy.() -> Unit = {}): DaemonSetUpdateStrategy {
+fun newDaemonSetUpdateStrategy(block : DaemonSetUpdateStrategy.() -> Unit = {}): DaemonSetUpdateStrategy {
   val instance = DaemonSetUpdateStrategy()
   instance.block()
   return instance
 }
 
 
-fun deployment(block : Deployment.() -> Unit = {}): Deployment {
+fun newDeployment(block : Deployment.() -> Unit = {}): Deployment {
   val instance = Deployment()
   instance.block()
   return instance
 }
 
 
-fun deploymentCondition(block : DeploymentCondition.() -> Unit = {}): DeploymentCondition {
+fun newDeploymentCondition(block : DeploymentCondition.() -> Unit = {}): DeploymentCondition {
   val instance = DeploymentCondition()
   instance.block()
   return instance
 }
 
 
-fun deploymentList(block : DeploymentList.() -> Unit = {}): DeploymentList {
+fun newDeploymentList(block : DeploymentList.() -> Unit = {}): DeploymentList {
   val instance = DeploymentList()
   instance.block()
   return instance
 }
 
 
-fun deploymentRollback(block : DeploymentRollback.() -> Unit = {}): DeploymentRollback {
+fun newDeploymentRollback(block : DeploymentRollback.() -> Unit = {}): DeploymentRollback {
   val instance = DeploymentRollback()
   instance.block()
   return instance
 }
 
 
-fun deploymentSpec(block : DeploymentSpec.() -> Unit = {}): DeploymentSpec {
+fun newDeploymentSpec(block : DeploymentSpec.() -> Unit = {}): DeploymentSpec {
   val instance = DeploymentSpec()
   instance.block()
   return instance
 }
 
 
-fun deploymentStatus(block : DeploymentStatus.() -> Unit = {}): DeploymentStatus {
+fun newDeploymentStatus(block : DeploymentStatus.() -> Unit = {}): DeploymentStatus {
   val instance = DeploymentStatus()
   instance.block()
   return instance
 }
 
 
-fun deploymentStrategy(block : DeploymentStrategy.() -> Unit = {}): DeploymentStrategy {
+fun newDeploymentStrategy(block : DeploymentStrategy.() -> Unit = {}): DeploymentStrategy {
   val instance = DeploymentStrategy()
   instance.block()
   return instance
 }
 
 
-fun fsGroupStrategyOptions(block : FSGroupStrategyOptions.() -> Unit = {}): FSGroupStrategyOptions {
+fun newFSGroupStrategyOptions(block : FSGroupStrategyOptions.() -> Unit = {}): FSGroupStrategyOptions {
   val instance = FSGroupStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun httpIngressPath(block : HTTPIngressPath.() -> Unit = {}): HTTPIngressPath {
+fun newHTTPIngressPath(block : HTTPIngressPath.() -> Unit = {}): HTTPIngressPath {
   val instance = HTTPIngressPath()
   instance.block()
   return instance
 }
 
 
-fun httpIngressRuleValue(block : HTTPIngressRuleValue.() -> Unit = {}): HTTPIngressRuleValue {
+fun newHTTPIngressRuleValue(block : HTTPIngressRuleValue.() -> Unit = {}): HTTPIngressRuleValue {
   val instance = HTTPIngressRuleValue()
   instance.block()
   return instance
 }
 
 
-fun hostPortRange(block : HostPortRange.() -> Unit = {}): HostPortRange {
+fun newHostPortRange(block : HostPortRange.() -> Unit = {}): HostPortRange {
   val instance = HostPortRange()
   instance.block()
   return instance
 }
 
 
-fun idRange(block : IDRange.() -> Unit = {}): IDRange {
+fun newIDRange(block : IDRange.() -> Unit = {}): IDRange {
   val instance = IDRange()
   instance.block()
   return instance
 }
 
 
-fun ingress(block : Ingress.() -> Unit = {}): Ingress {
+fun newIngress(block : Ingress.() -> Unit = {}): Ingress {
   val instance = Ingress()
   instance.block()
   return instance
 }
 
 
-fun ingressBackend(block : IngressBackend.() -> Unit = {}): IngressBackend {
+fun newIngressBackend(block : IngressBackend.() -> Unit = {}): IngressBackend {
   val instance = IngressBackend()
   instance.block()
   return instance
 }
 
 
-fun ingressList(block : IngressList.() -> Unit = {}): IngressList {
+fun newIngressList(block : IngressList.() -> Unit = {}): IngressList {
   val instance = IngressList()
   instance.block()
   return instance
 }
 
 
-fun ingressRule(block : IngressRule.() -> Unit = {}): IngressRule {
+fun newIngressRule(block : IngressRule.() -> Unit = {}): IngressRule {
   val instance = IngressRule()
   instance.block()
   return instance
 }
 
 
-fun ingressSpec(block : IngressSpec.() -> Unit = {}): IngressSpec {
+fun newIngressSpec(block : IngressSpec.() -> Unit = {}): IngressSpec {
   val instance = IngressSpec()
   instance.block()
   return instance
 }
 
 
-fun ingressStatus(block : IngressStatus.() -> Unit = {}): IngressStatus {
+fun newIngressStatus(block : IngressStatus.() -> Unit = {}): IngressStatus {
   val instance = IngressStatus()
   instance.block()
   return instance
 }
 
 
-fun ingressTLS(block : IngressTLS.() -> Unit = {}): IngressTLS {
+fun newIngressTLS(block : IngressTLS.() -> Unit = {}): IngressTLS {
   val instance = IngressTLS()
   instance.block()
   return instance
 }
 
 
-fun kubernetesRunAsUserStrategyOptions(block : KubernetesRunAsUserStrategyOptions.() -> Unit = {}): KubernetesRunAsUserStrategyOptions {
+fun newKubernetesRunAsUserStrategyOptions(block : KubernetesRunAsUserStrategyOptions.() -> Unit = {}): KubernetesRunAsUserStrategyOptions {
   val instance = KubernetesRunAsUserStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun networkPolicy(block : NetworkPolicy.() -> Unit = {}): NetworkPolicy {
+fun newNetworkPolicy(block : NetworkPolicy.() -> Unit = {}): NetworkPolicy {
   val instance = NetworkPolicy()
   instance.block()
   return instance
 }
 
 
-fun networkPolicyIngressRule(block : NetworkPolicyIngressRule.() -> Unit = {}): NetworkPolicyIngressRule {
+fun newNetworkPolicyIngressRule(block : NetworkPolicyIngressRule.() -> Unit = {}): NetworkPolicyIngressRule {
   val instance = NetworkPolicyIngressRule()
   instance.block()
   return instance
 }
 
 
-fun networkPolicyList(block : NetworkPolicyList.() -> Unit = {}): NetworkPolicyList {
+fun newNetworkPolicyList(block : NetworkPolicyList.() -> Unit = {}): NetworkPolicyList {
   val instance = NetworkPolicyList()
   instance.block()
   return instance
 }
 
 
-fun networkPolicyPeer(block : NetworkPolicyPeer.() -> Unit = {}): NetworkPolicyPeer {
+fun newNetworkPolicyPeer(block : NetworkPolicyPeer.() -> Unit = {}): NetworkPolicyPeer {
   val instance = NetworkPolicyPeer()
   instance.block()
   return instance
 }
 
 
-fun networkPolicyPort(block : NetworkPolicyPort.() -> Unit = {}): NetworkPolicyPort {
+fun newNetworkPolicyPort(block : NetworkPolicyPort.() -> Unit = {}): NetworkPolicyPort {
   val instance = NetworkPolicyPort()
   instance.block()
   return instance
 }
 
 
-fun networkPolicySpec(block : NetworkPolicySpec.() -> Unit = {}): NetworkPolicySpec {
+fun newNetworkPolicySpec(block : NetworkPolicySpec.() -> Unit = {}): NetworkPolicySpec {
   val instance = NetworkPolicySpec()
   instance.block()
   return instance
 }
 
 
-fun podSecurityPolicy(block : PodSecurityPolicy.() -> Unit = {}): PodSecurityPolicy {
+fun newPodSecurityPolicy(block : PodSecurityPolicy.() -> Unit = {}): PodSecurityPolicy {
   val instance = PodSecurityPolicy()
   instance.block()
   return instance
 }
 
 
-fun podSecurityPolicyList(block : PodSecurityPolicyList.() -> Unit = {}): PodSecurityPolicyList {
+fun newPodSecurityPolicyList(block : PodSecurityPolicyList.() -> Unit = {}): PodSecurityPolicyList {
   val instance = PodSecurityPolicyList()
   instance.block()
   return instance
 }
 
 
-fun podSecurityPolicySpec(block : PodSecurityPolicySpec.() -> Unit = {}): PodSecurityPolicySpec {
+fun newPodSecurityPolicySpec(block : PodSecurityPolicySpec.() -> Unit = {}): PodSecurityPolicySpec {
   val instance = PodSecurityPolicySpec()
   instance.block()
   return instance
 }
 
 
-fun replicaSet(block : ReplicaSet.() -> Unit = {}): ReplicaSet {
+fun newReplicaSet(block : ReplicaSet.() -> Unit = {}): ReplicaSet {
   val instance = ReplicaSet()
   instance.block()
   return instance
 }
 
 
-fun replicaSetCondition(block : ReplicaSetCondition.() -> Unit = {}): ReplicaSetCondition {
+fun newReplicaSetCondition(block : ReplicaSetCondition.() -> Unit = {}): ReplicaSetCondition {
   val instance = ReplicaSetCondition()
   instance.block()
   return instance
 }
 
 
-fun replicaSetList(block : ReplicaSetList.() -> Unit = {}): ReplicaSetList {
+fun newReplicaSetList(block : ReplicaSetList.() -> Unit = {}): ReplicaSetList {
   val instance = ReplicaSetList()
   instance.block()
   return instance
 }
 
 
-fun replicaSetSpec(block : ReplicaSetSpec.() -> Unit = {}): ReplicaSetSpec {
+fun newReplicaSetSpec(block : ReplicaSetSpec.() -> Unit = {}): ReplicaSetSpec {
   val instance = ReplicaSetSpec()
   instance.block()
   return instance
 }
 
 
-fun replicaSetStatus(block : ReplicaSetStatus.() -> Unit = {}): ReplicaSetStatus {
+fun newReplicaSetStatus(block : ReplicaSetStatus.() -> Unit = {}): ReplicaSetStatus {
   val instance = ReplicaSetStatus()
   instance.block()
   return instance
 }
 
 
-fun rollbackConfig(block : RollbackConfig.() -> Unit = {}): RollbackConfig {
+fun newRollbackConfig(block : RollbackConfig.() -> Unit = {}): RollbackConfig {
   val instance = RollbackConfig()
   instance.block()
   return instance
 }
 
 
-fun rollingUpdateDaemonSet(block : RollingUpdateDaemonSet.() -> Unit = {}): RollingUpdateDaemonSet {
+fun newRollingUpdateDaemonSet(block : RollingUpdateDaemonSet.() -> Unit = {}): RollingUpdateDaemonSet {
   val instance = RollingUpdateDaemonSet()
   instance.block()
   return instance
 }
 
 
-fun rollingUpdateDeployment(block : RollingUpdateDeployment.() -> Unit = {}): RollingUpdateDeployment {
+fun newRollingUpdateDeployment(block : RollingUpdateDeployment.() -> Unit = {}): RollingUpdateDeployment {
   val instance = RollingUpdateDeployment()
   instance.block()
   return instance
 }
 
 
-fun rollingUpdateStatefulSetStrategy(block : RollingUpdateStatefulSetStrategy.() -> Unit = {}): RollingUpdateStatefulSetStrategy {
+fun newRollingUpdateStatefulSetStrategy(block : RollingUpdateStatefulSetStrategy.() -> Unit = {}): RollingUpdateStatefulSetStrategy {
   val instance = RollingUpdateStatefulSetStrategy()
   instance.block()
   return instance
 }
 
 
-fun seLinuxStrategyOptions(block : SELinuxStrategyOptions.() -> Unit = {}): SELinuxStrategyOptions {
+fun newSELinuxStrategyOptions(block : SELinuxStrategyOptions.() -> Unit = {}): SELinuxStrategyOptions {
   val instance = SELinuxStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun scale(block : Scale.() -> Unit = {}): Scale {
+fun newScale(block : Scale.() -> Unit = {}): Scale {
   val instance = Scale()
   instance.block()
   return instance
 }
 
 
-fun scaleSpec(block : ScaleSpec.() -> Unit = {}): ScaleSpec {
+fun newScaleSpec(block : ScaleSpec.() -> Unit = {}): ScaleSpec {
   val instance = ScaleSpec()
   instance.block()
   return instance
 }
 
 
-fun scaleStatus(block : ScaleStatus.() -> Unit = {}): ScaleStatus {
+fun newScaleStatus(block : ScaleStatus.() -> Unit = {}): ScaleStatus {
   val instance = ScaleStatus()
   instance.block()
   return instance
 }
 
 
-fun statefulSet(block : StatefulSet.() -> Unit = {}): StatefulSet {
+fun newStatefulSet(block : StatefulSet.() -> Unit = {}): StatefulSet {
   val instance = StatefulSet()
   instance.block()
   return instance
 }
 
 
-fun statefulSetList(block : StatefulSetList.() -> Unit = {}): StatefulSetList {
+fun newStatefulSetList(block : StatefulSetList.() -> Unit = {}): StatefulSetList {
   val instance = StatefulSetList()
   instance.block()
   return instance
 }
 
 
-fun statefulSetSpec(block : StatefulSetSpec.() -> Unit = {}): StatefulSetSpec {
+fun newStatefulSetSpec(block : StatefulSetSpec.() -> Unit = {}): StatefulSetSpec {
   val instance = StatefulSetSpec()
   instance.block()
   return instance
 }
 
 
-fun statefulSetStatus(block : StatefulSetStatus.() -> Unit = {}): StatefulSetStatus {
+fun newStatefulSetStatus(block : StatefulSetStatus.() -> Unit = {}): StatefulSetStatus {
   val instance = StatefulSetStatus()
   instance.block()
   return instance
 }
 
 
-fun statefulSetUpdateStrategy(block : StatefulSetUpdateStrategy.() -> Unit = {}): StatefulSetUpdateStrategy {
+fun newStatefulSetUpdateStrategy(block : StatefulSetUpdateStrategy.() -> Unit = {}): StatefulSetUpdateStrategy {
   val instance = StatefulSetUpdateStrategy()
   instance.block()
   return instance
 }
 
 
-fun supplementalGroupsStrategyOptions(block : SupplementalGroupsStrategyOptions.() -> Unit = {}): SupplementalGroupsStrategyOptions {
+fun newSupplementalGroupsStrategyOptions(block : SupplementalGroupsStrategyOptions.() -> Unit = {}): SupplementalGroupsStrategyOptions {
   val instance = SupplementalGroupsStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun thirdPartyResource(block : ThirdPartyResource.() -> Unit = {}): ThirdPartyResource {
+fun newThirdPartyResource(block : ThirdPartyResource.() -> Unit = {}): ThirdPartyResource {
   val instance = ThirdPartyResource()
   instance.block()
   return instance
 }
 
 
-fun thirdPartyResourceList(block : ThirdPartyResourceList.() -> Unit = {}): ThirdPartyResourceList {
+fun newThirdPartyResourceList(block : ThirdPartyResourceList.() -> Unit = {}): ThirdPartyResourceList {
   val instance = ThirdPartyResourceList()
   instance.block()
   return instance
 }
 
 
-fun podDisruptionBudget(block : PodDisruptionBudget.() -> Unit = {}): PodDisruptionBudget {
+fun newPodDisruptionBudget(block : PodDisruptionBudget.() -> Unit = {}): PodDisruptionBudget {
   val instance = PodDisruptionBudget()
   instance.block()
   return instance
 }
 
 
-fun podDisruptionBudgetList(block : PodDisruptionBudgetList.() -> Unit = {}): PodDisruptionBudgetList {
+fun newPodDisruptionBudgetList(block : PodDisruptionBudgetList.() -> Unit = {}): PodDisruptionBudgetList {
   val instance = PodDisruptionBudgetList()
   instance.block()
   return instance
 }
 
 
-fun podDisruptionBudgetSpec(block : PodDisruptionBudgetSpec.() -> Unit = {}): PodDisruptionBudgetSpec {
+fun newPodDisruptionBudgetSpec(block : PodDisruptionBudgetSpec.() -> Unit = {}): PodDisruptionBudgetSpec {
   val instance = PodDisruptionBudgetSpec()
   instance.block()
   return instance
 }
 
 
-fun podDisruptionBudgetStatus(block : PodDisruptionBudgetStatus.() -> Unit = {}): PodDisruptionBudgetStatus {
+fun newPodDisruptionBudgetStatus(block : PodDisruptionBudgetStatus.() -> Unit = {}): PodDisruptionBudgetStatus {
   val instance = PodDisruptionBudgetStatus()
   instance.block()
   return instance

--- a/kubernetes/dsl/src/main/kotlin-gen/com/fkorotkov/openshift/ClassBuilders.kt
+++ b/kubernetes/dsl/src/main/kotlin-gen/com/fkorotkov/openshift/ClassBuilders.kt
@@ -150,1029 +150,1029 @@ import io.fabric8.openshift.api.model.UserRestriction
 import io.fabric8.openshift.api.model.WebHookTrigger
 
 
-fun binaryBuildSource(block : BinaryBuildSource.() -> Unit = {}): BinaryBuildSource {
+fun newBinaryBuildSource(block : BinaryBuildSource.() -> Unit = {}): BinaryBuildSource {
   val instance = BinaryBuildSource()
   instance.block()
   return instance
 }
 
 
-fun bitbucketWebHookCause(block : BitbucketWebHookCause.() -> Unit = {}): BitbucketWebHookCause {
+fun newBitbucketWebHookCause(block : BitbucketWebHookCause.() -> Unit = {}): BitbucketWebHookCause {
   val instance = BitbucketWebHookCause()
   instance.block()
   return instance
 }
 
 
-fun build(block : Build.() -> Unit = {}): Build {
+fun newBuild(block : Build.() -> Unit = {}): Build {
   val instance = Build()
   instance.block()
   return instance
 }
 
 
-fun buildConfig(block : BuildConfig.() -> Unit = {}): BuildConfig {
+fun newBuildConfig(block : BuildConfig.() -> Unit = {}): BuildConfig {
   val instance = BuildConfig()
   instance.block()
   return instance
 }
 
 
-fun buildConfigList(block : BuildConfigList.() -> Unit = {}): BuildConfigList {
+fun newBuildConfigList(block : BuildConfigList.() -> Unit = {}): BuildConfigList {
   val instance = BuildConfigList()
   instance.block()
   return instance
 }
 
 
-fun buildConfigSpec(block : BuildConfigSpec.() -> Unit = {}): BuildConfigSpec {
+fun newBuildConfigSpec(block : BuildConfigSpec.() -> Unit = {}): BuildConfigSpec {
   val instance = BuildConfigSpec()
   instance.block()
   return instance
 }
 
 
-fun buildConfigStatus(block : BuildConfigStatus.() -> Unit = {}): BuildConfigStatus {
+fun newBuildConfigStatus(block : BuildConfigStatus.() -> Unit = {}): BuildConfigStatus {
   val instance = BuildConfigStatus()
   instance.block()
   return instance
 }
 
 
-fun buildList(block : BuildList.() -> Unit = {}): BuildList {
+fun newBuildList(block : BuildList.() -> Unit = {}): BuildList {
   val instance = BuildList()
   instance.block()
   return instance
 }
 
 
-fun buildOutput(block : BuildOutput.() -> Unit = {}): BuildOutput {
+fun newBuildOutput(block : BuildOutput.() -> Unit = {}): BuildOutput {
   val instance = BuildOutput()
   instance.block()
   return instance
 }
 
 
-fun buildPostCommitSpec(block : BuildPostCommitSpec.() -> Unit = {}): BuildPostCommitSpec {
+fun newBuildPostCommitSpec(block : BuildPostCommitSpec.() -> Unit = {}): BuildPostCommitSpec {
   val instance = BuildPostCommitSpec()
   instance.block()
   return instance
 }
 
 
-fun buildRequest(block : BuildRequest.() -> Unit = {}): BuildRequest {
+fun newBuildRequest(block : BuildRequest.() -> Unit = {}): BuildRequest {
   val instance = BuildRequest()
   instance.block()
   return instance
 }
 
 
-fun buildSource(block : BuildSource.() -> Unit = {}): BuildSource {
+fun newBuildSource(block : BuildSource.() -> Unit = {}): BuildSource {
   val instance = BuildSource()
   instance.block()
   return instance
 }
 
 
-fun buildSpec(block : BuildSpec.() -> Unit = {}): BuildSpec {
+fun newBuildSpec(block : BuildSpec.() -> Unit = {}): BuildSpec {
   val instance = BuildSpec()
   instance.block()
   return instance
 }
 
 
-fun buildStatus(block : BuildStatus.() -> Unit = {}): BuildStatus {
+fun newBuildStatus(block : BuildStatus.() -> Unit = {}): BuildStatus {
   val instance = BuildStatus()
   instance.block()
   return instance
 }
 
 
-fun buildStatusOutput(block : BuildStatusOutput.() -> Unit = {}): BuildStatusOutput {
+fun newBuildStatusOutput(block : BuildStatusOutput.() -> Unit = {}): BuildStatusOutput {
   val instance = BuildStatusOutput()
   instance.block()
   return instance
 }
 
 
-fun buildStatusOutputTo(block : BuildStatusOutputTo.() -> Unit = {}): BuildStatusOutputTo {
+fun newBuildStatusOutputTo(block : BuildStatusOutputTo.() -> Unit = {}): BuildStatusOutputTo {
   val instance = BuildStatusOutputTo()
   instance.block()
   return instance
 }
 
 
-fun buildStrategy(block : BuildStrategy.() -> Unit = {}): BuildStrategy {
+fun newBuildStrategy(block : BuildStrategy.() -> Unit = {}): BuildStrategy {
   val instance = BuildStrategy()
   instance.block()
   return instance
 }
 
 
-fun buildTriggerCause(block : BuildTriggerCause.() -> Unit = {}): BuildTriggerCause {
+fun newBuildTriggerCause(block : BuildTriggerCause.() -> Unit = {}): BuildTriggerCause {
   val instance = BuildTriggerCause()
   instance.block()
   return instance
 }
 
 
-fun buildTriggerPolicy(block : BuildTriggerPolicy.() -> Unit = {}): BuildTriggerPolicy {
+fun newBuildTriggerPolicy(block : BuildTriggerPolicy.() -> Unit = {}): BuildTriggerPolicy {
   val instance = BuildTriggerPolicy()
   instance.block()
   return instance
 }
 
 
-fun clusterPolicy(block : ClusterPolicy.() -> Unit = {}): ClusterPolicy {
+fun newClusterPolicy(block : ClusterPolicy.() -> Unit = {}): ClusterPolicy {
   val instance = ClusterPolicy()
   instance.block()
   return instance
 }
 
 
-fun clusterPolicyBinding(block : ClusterPolicyBinding.() -> Unit = {}): ClusterPolicyBinding {
+fun newClusterPolicyBinding(block : ClusterPolicyBinding.() -> Unit = {}): ClusterPolicyBinding {
   val instance = ClusterPolicyBinding()
   instance.block()
   return instance
 }
 
 
-fun clusterPolicyBindingList(block : ClusterPolicyBindingList.() -> Unit = {}): ClusterPolicyBindingList {
+fun newClusterPolicyBindingList(block : ClusterPolicyBindingList.() -> Unit = {}): ClusterPolicyBindingList {
   val instance = ClusterPolicyBindingList()
   instance.block()
   return instance
 }
 
 
-fun clusterPolicyList(block : ClusterPolicyList.() -> Unit = {}): ClusterPolicyList {
+fun newClusterPolicyList(block : ClusterPolicyList.() -> Unit = {}): ClusterPolicyList {
   val instance = ClusterPolicyList()
   instance.block()
   return instance
 }
 
 
-fun clusterRole(block : ClusterRole.() -> Unit = {}): ClusterRole {
+fun newClusterRole(block : ClusterRole.() -> Unit = {}): ClusterRole {
   val instance = ClusterRole()
   instance.block()
   return instance
 }
 
 
-fun clusterRoleBinding(block : ClusterRoleBinding.() -> Unit = {}): ClusterRoleBinding {
+fun newClusterRoleBinding(block : ClusterRoleBinding.() -> Unit = {}): ClusterRoleBinding {
   val instance = ClusterRoleBinding()
   instance.block()
   return instance
 }
 
 
-fun clusterRoleBindingList(block : ClusterRoleBindingList.() -> Unit = {}): ClusterRoleBindingList {
+fun newClusterRoleBindingList(block : ClusterRoleBindingList.() -> Unit = {}): ClusterRoleBindingList {
   val instance = ClusterRoleBindingList()
   instance.block()
   return instance
 }
 
 
-fun clusterRoleScopeRestriction(block : ClusterRoleScopeRestriction.() -> Unit = {}): ClusterRoleScopeRestriction {
+fun newClusterRoleScopeRestriction(block : ClusterRoleScopeRestriction.() -> Unit = {}): ClusterRoleScopeRestriction {
   val instance = ClusterRoleScopeRestriction()
   instance.block()
   return instance
 }
 
 
-fun customBuildStrategy(block : CustomBuildStrategy.() -> Unit = {}): CustomBuildStrategy {
+fun newCustomBuildStrategy(block : CustomBuildStrategy.() -> Unit = {}): CustomBuildStrategy {
   val instance = CustomBuildStrategy()
   instance.block()
   return instance
 }
 
 
-fun customDeploymentStrategyParams(block : CustomDeploymentStrategyParams.() -> Unit = {}): CustomDeploymentStrategyParams {
+fun newCustomDeploymentStrategyParams(block : CustomDeploymentStrategyParams.() -> Unit = {}): CustomDeploymentStrategyParams {
   val instance = CustomDeploymentStrategyParams()
   instance.block()
   return instance
 }
 
 
-fun deploymentCause(block : DeploymentCause.() -> Unit = {}): DeploymentCause {
+fun newDeploymentCause(block : DeploymentCause.() -> Unit = {}): DeploymentCause {
   val instance = DeploymentCause()
   instance.block()
   return instance
 }
 
 
-fun deploymentCauseImageTrigger(block : DeploymentCauseImageTrigger.() -> Unit = {}): DeploymentCauseImageTrigger {
+fun newDeploymentCauseImageTrigger(block : DeploymentCauseImageTrigger.() -> Unit = {}): DeploymentCauseImageTrigger {
   val instance = DeploymentCauseImageTrigger()
   instance.block()
   return instance
 }
 
 
-fun deploymentCondition(block : DeploymentCondition.() -> Unit = {}): DeploymentCondition {
+fun newDeploymentCondition(block : DeploymentCondition.() -> Unit = {}): DeploymentCondition {
   val instance = DeploymentCondition()
   instance.block()
   return instance
 }
 
 
-fun deploymentConfig(block : DeploymentConfig.() -> Unit = {}): DeploymentConfig {
+fun newDeploymentConfig(block : DeploymentConfig.() -> Unit = {}): DeploymentConfig {
   val instance = DeploymentConfig()
   instance.block()
   return instance
 }
 
 
-fun deploymentConfigList(block : DeploymentConfigList.() -> Unit = {}): DeploymentConfigList {
+fun newDeploymentConfigList(block : DeploymentConfigList.() -> Unit = {}): DeploymentConfigList {
   val instance = DeploymentConfigList()
   instance.block()
   return instance
 }
 
 
-fun deploymentConfigSpec(block : DeploymentConfigSpec.() -> Unit = {}): DeploymentConfigSpec {
+fun newDeploymentConfigSpec(block : DeploymentConfigSpec.() -> Unit = {}): DeploymentConfigSpec {
   val instance = DeploymentConfigSpec()
   instance.block()
   return instance
 }
 
 
-fun deploymentConfigStatus(block : DeploymentConfigStatus.() -> Unit = {}): DeploymentConfigStatus {
+fun newDeploymentConfigStatus(block : DeploymentConfigStatus.() -> Unit = {}): DeploymentConfigStatus {
   val instance = DeploymentConfigStatus()
   instance.block()
   return instance
 }
 
 
-fun deploymentDetails(block : DeploymentDetails.() -> Unit = {}): DeploymentDetails {
+fun newDeploymentDetails(block : DeploymentDetails.() -> Unit = {}): DeploymentDetails {
   val instance = DeploymentDetails()
   instance.block()
   return instance
 }
 
 
-fun deploymentStrategy(block : DeploymentStrategy.() -> Unit = {}): DeploymentStrategy {
+fun newDeploymentStrategy(block : DeploymentStrategy.() -> Unit = {}): DeploymentStrategy {
   val instance = DeploymentStrategy()
   instance.block()
   return instance
 }
 
 
-fun deploymentTriggerImageChangeParams(block : DeploymentTriggerImageChangeParams.() -> Unit = {}): DeploymentTriggerImageChangeParams {
+fun newDeploymentTriggerImageChangeParams(block : DeploymentTriggerImageChangeParams.() -> Unit = {}): DeploymentTriggerImageChangeParams {
   val instance = DeploymentTriggerImageChangeParams()
   instance.block()
   return instance
 }
 
 
-fun deploymentTriggerPolicy(block : DeploymentTriggerPolicy.() -> Unit = {}): DeploymentTriggerPolicy {
+fun newDeploymentTriggerPolicy(block : DeploymentTriggerPolicy.() -> Unit = {}): DeploymentTriggerPolicy {
   val instance = DeploymentTriggerPolicy()
   instance.block()
   return instance
 }
 
 
-fun dockerBuildStrategy(block : DockerBuildStrategy.() -> Unit = {}): DockerBuildStrategy {
+fun newDockerBuildStrategy(block : DockerBuildStrategy.() -> Unit = {}): DockerBuildStrategy {
   val instance = DockerBuildStrategy()
   instance.block()
   return instance
 }
 
 
-fun dockerStrategyOptions(block : DockerStrategyOptions.() -> Unit = {}): DockerStrategyOptions {
+fun newDockerStrategyOptions(block : DockerStrategyOptions.() -> Unit = {}): DockerStrategyOptions {
   val instance = DockerStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun execNewPodHook(block : ExecNewPodHook.() -> Unit = {}): ExecNewPodHook {
+fun newExecNewPodHook(block : ExecNewPodHook.() -> Unit = {}): ExecNewPodHook {
   val instance = ExecNewPodHook()
   instance.block()
   return instance
 }
 
 
-fun fsGroupStrategyOptions(block : FSGroupStrategyOptions.() -> Unit = {}): FSGroupStrategyOptions {
+fun newFSGroupStrategyOptions(block : FSGroupStrategyOptions.() -> Unit = {}): FSGroupStrategyOptions {
   val instance = FSGroupStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun genericWebHookCause(block : GenericWebHookCause.() -> Unit = {}): GenericWebHookCause {
+fun newGenericWebHookCause(block : GenericWebHookCause.() -> Unit = {}): GenericWebHookCause {
   val instance = GenericWebHookCause()
   instance.block()
   return instance
 }
 
 
-fun gitBuildSource(block : GitBuildSource.() -> Unit = {}): GitBuildSource {
+fun newGitBuildSource(block : GitBuildSource.() -> Unit = {}): GitBuildSource {
   val instance = GitBuildSource()
   instance.block()
   return instance
 }
 
 
-fun gitHubWebHookCause(block : GitHubWebHookCause.() -> Unit = {}): GitHubWebHookCause {
+fun newGitHubWebHookCause(block : GitHubWebHookCause.() -> Unit = {}): GitHubWebHookCause {
   val instance = GitHubWebHookCause()
   instance.block()
   return instance
 }
 
 
-fun gitLabWebHookCause(block : GitLabWebHookCause.() -> Unit = {}): GitLabWebHookCause {
+fun newGitLabWebHookCause(block : GitLabWebHookCause.() -> Unit = {}): GitLabWebHookCause {
   val instance = GitLabWebHookCause()
   instance.block()
   return instance
 }
 
 
-fun gitSourceRevision(block : GitSourceRevision.() -> Unit = {}): GitSourceRevision {
+fun newGitSourceRevision(block : GitSourceRevision.() -> Unit = {}): GitSourceRevision {
   val instance = GitSourceRevision()
   instance.block()
   return instance
 }
 
 
-fun group(block : Group.() -> Unit = {}): Group {
+fun newGroup(block : Group.() -> Unit = {}): Group {
   val instance = Group()
   instance.block()
   return instance
 }
 
 
-fun groupList(block : GroupList.() -> Unit = {}): GroupList {
+fun newGroupList(block : GroupList.() -> Unit = {}): GroupList {
   val instance = GroupList()
   instance.block()
   return instance
 }
 
 
-fun groupRestriction(block : GroupRestriction.() -> Unit = {}): GroupRestriction {
+fun newGroupRestriction(block : GroupRestriction.() -> Unit = {}): GroupRestriction {
   val instance = GroupRestriction()
   instance.block()
   return instance
 }
 
 
-fun idRange(block : IDRange.() -> Unit = {}): IDRange {
+fun newIDRange(block : IDRange.() -> Unit = {}): IDRange {
   val instance = IDRange()
   instance.block()
   return instance
 }
 
 
-fun identity(block : Identity.() -> Unit = {}): Identity {
+fun newIdentity(block : Identity.() -> Unit = {}): Identity {
   val instance = Identity()
   instance.block()
   return instance
 }
 
 
-fun identityList(block : IdentityList.() -> Unit = {}): IdentityList {
+fun newIdentityList(block : IdentityList.() -> Unit = {}): IdentityList {
   val instance = IdentityList()
   instance.block()
   return instance
 }
 
 
-fun image(block : Image.() -> Unit = {}): Image {
+fun newImage(block : Image.() -> Unit = {}): Image {
   val instance = Image()
   instance.block()
   return instance
 }
 
 
-fun imageChangeCause(block : ImageChangeCause.() -> Unit = {}): ImageChangeCause {
+fun newImageChangeCause(block : ImageChangeCause.() -> Unit = {}): ImageChangeCause {
   val instance = ImageChangeCause()
   instance.block()
   return instance
 }
 
 
-fun imageChangeTrigger(block : ImageChangeTrigger.() -> Unit = {}): ImageChangeTrigger {
+fun newImageChangeTrigger(block : ImageChangeTrigger.() -> Unit = {}): ImageChangeTrigger {
   val instance = ImageChangeTrigger()
   instance.block()
   return instance
 }
 
 
-fun imageLabel(block : ImageLabel.() -> Unit = {}): ImageLabel {
+fun newImageLabel(block : ImageLabel.() -> Unit = {}): ImageLabel {
   val instance = ImageLabel()
   instance.block()
   return instance
 }
 
 
-fun imageLayer(block : ImageLayer.() -> Unit = {}): ImageLayer {
+fun newImageLayer(block : ImageLayer.() -> Unit = {}): ImageLayer {
   val instance = ImageLayer()
   instance.block()
   return instance
 }
 
 
-fun imageList(block : ImageList.() -> Unit = {}): ImageList {
+fun newImageList(block : ImageList.() -> Unit = {}): ImageList {
   val instance = ImageList()
   instance.block()
   return instance
 }
 
 
-fun imageLookupPolicy(block : ImageLookupPolicy.() -> Unit = {}): ImageLookupPolicy {
+fun newImageLookupPolicy(block : ImageLookupPolicy.() -> Unit = {}): ImageLookupPolicy {
   val instance = ImageLookupPolicy()
   instance.block()
   return instance
 }
 
 
-fun imageSignature(block : ImageSignature.() -> Unit = {}): ImageSignature {
+fun newImageSignature(block : ImageSignature.() -> Unit = {}): ImageSignature {
   val instance = ImageSignature()
   instance.block()
   return instance
 }
 
 
-fun imageSource(block : ImageSource.() -> Unit = {}): ImageSource {
+fun newImageSource(block : ImageSource.() -> Unit = {}): ImageSource {
   val instance = ImageSource()
   instance.block()
   return instance
 }
 
 
-fun imageSourcePath(block : ImageSourcePath.() -> Unit = {}): ImageSourcePath {
+fun newImageSourcePath(block : ImageSourcePath.() -> Unit = {}): ImageSourcePath {
   val instance = ImageSourcePath()
   instance.block()
   return instance
 }
 
 
-fun imageStream(block : ImageStream.() -> Unit = {}): ImageStream {
+fun newImageStream(block : ImageStream.() -> Unit = {}): ImageStream {
   val instance = ImageStream()
   instance.block()
   return instance
 }
 
 
-fun imageStreamList(block : ImageStreamList.() -> Unit = {}): ImageStreamList {
+fun newImageStreamList(block : ImageStreamList.() -> Unit = {}): ImageStreamList {
   val instance = ImageStreamList()
   instance.block()
   return instance
 }
 
 
-fun imageStreamSpec(block : ImageStreamSpec.() -> Unit = {}): ImageStreamSpec {
+fun newImageStreamSpec(block : ImageStreamSpec.() -> Unit = {}): ImageStreamSpec {
   val instance = ImageStreamSpec()
   instance.block()
   return instance
 }
 
 
-fun imageStreamStatus(block : ImageStreamStatus.() -> Unit = {}): ImageStreamStatus {
+fun newImageStreamStatus(block : ImageStreamStatus.() -> Unit = {}): ImageStreamStatus {
   val instance = ImageStreamStatus()
   instance.block()
   return instance
 }
 
 
-fun imageStreamTag(block : ImageStreamTag.() -> Unit = {}): ImageStreamTag {
+fun newImageStreamTag(block : ImageStreamTag.() -> Unit = {}): ImageStreamTag {
   val instance = ImageStreamTag()
   instance.block()
   return instance
 }
 
 
-fun imageStreamTagList(block : ImageStreamTagList.() -> Unit = {}): ImageStreamTagList {
+fun newImageStreamTagList(block : ImageStreamTagList.() -> Unit = {}): ImageStreamTagList {
   val instance = ImageStreamTagList()
   instance.block()
   return instance
 }
 
 
-fun jenkinsPipelineBuildStrategy(block : JenkinsPipelineBuildStrategy.() -> Unit = {}): JenkinsPipelineBuildStrategy {
+fun newJenkinsPipelineBuildStrategy(block : JenkinsPipelineBuildStrategy.() -> Unit = {}): JenkinsPipelineBuildStrategy {
   val instance = JenkinsPipelineBuildStrategy()
   instance.block()
   return instance
 }
 
 
-fun lifecycleHook(block : LifecycleHook.() -> Unit = {}): LifecycleHook {
+fun newLifecycleHook(block : LifecycleHook.() -> Unit = {}): LifecycleHook {
   val instance = LifecycleHook()
   instance.block()
   return instance
 }
 
 
-fun localSubjectAccessReview(block : LocalSubjectAccessReview.() -> Unit = {}): LocalSubjectAccessReview {
+fun newLocalSubjectAccessReview(block : LocalSubjectAccessReview.() -> Unit = {}): LocalSubjectAccessReview {
   val instance = LocalSubjectAccessReview()
   instance.block()
   return instance
 }
 
 
-fun namedClusterRole(block : NamedClusterRole.() -> Unit = {}): NamedClusterRole {
+fun newNamedClusterRole(block : NamedClusterRole.() -> Unit = {}): NamedClusterRole {
   val instance = NamedClusterRole()
   instance.block()
   return instance
 }
 
 
-fun namedClusterRoleBinding(block : NamedClusterRoleBinding.() -> Unit = {}): NamedClusterRoleBinding {
+fun newNamedClusterRoleBinding(block : NamedClusterRoleBinding.() -> Unit = {}): NamedClusterRoleBinding {
   val instance = NamedClusterRoleBinding()
   instance.block()
   return instance
 }
 
 
-fun namedRole(block : NamedRole.() -> Unit = {}): NamedRole {
+fun newNamedRole(block : NamedRole.() -> Unit = {}): NamedRole {
   val instance = NamedRole()
   instance.block()
   return instance
 }
 
 
-fun namedRoleBinding(block : NamedRoleBinding.() -> Unit = {}): NamedRoleBinding {
+fun newNamedRoleBinding(block : NamedRoleBinding.() -> Unit = {}): NamedRoleBinding {
   val instance = NamedRoleBinding()
   instance.block()
   return instance
 }
 
 
-fun namedTagEventList(block : NamedTagEventList.() -> Unit = {}): NamedTagEventList {
+fun newNamedTagEventList(block : NamedTagEventList.() -> Unit = {}): NamedTagEventList {
   val instance = NamedTagEventList()
   instance.block()
   return instance
 }
 
 
-fun oAuthAccessToken(block : OAuthAccessToken.() -> Unit = {}): OAuthAccessToken {
+fun newOAuthAccessToken(block : OAuthAccessToken.() -> Unit = {}): OAuthAccessToken {
   val instance = OAuthAccessToken()
   instance.block()
   return instance
 }
 
 
-fun oAuthAccessTokenList(block : OAuthAccessTokenList.() -> Unit = {}): OAuthAccessTokenList {
+fun newOAuthAccessTokenList(block : OAuthAccessTokenList.() -> Unit = {}): OAuthAccessTokenList {
   val instance = OAuthAccessTokenList()
   instance.block()
   return instance
 }
 
 
-fun oAuthAuthorizeToken(block : OAuthAuthorizeToken.() -> Unit = {}): OAuthAuthorizeToken {
+fun newOAuthAuthorizeToken(block : OAuthAuthorizeToken.() -> Unit = {}): OAuthAuthorizeToken {
   val instance = OAuthAuthorizeToken()
   instance.block()
   return instance
 }
 
 
-fun oAuthAuthorizeTokenList(block : OAuthAuthorizeTokenList.() -> Unit = {}): OAuthAuthorizeTokenList {
+fun newOAuthAuthorizeTokenList(block : OAuthAuthorizeTokenList.() -> Unit = {}): OAuthAuthorizeTokenList {
   val instance = OAuthAuthorizeTokenList()
   instance.block()
   return instance
 }
 
 
-fun oAuthClient(block : OAuthClient.() -> Unit = {}): OAuthClient {
+fun newOAuthClient(block : OAuthClient.() -> Unit = {}): OAuthClient {
   val instance = OAuthClient()
   instance.block()
   return instance
 }
 
 
-fun oAuthClientAuthorization(block : OAuthClientAuthorization.() -> Unit = {}): OAuthClientAuthorization {
+fun newOAuthClientAuthorization(block : OAuthClientAuthorization.() -> Unit = {}): OAuthClientAuthorization {
   val instance = OAuthClientAuthorization()
   instance.block()
   return instance
 }
 
 
-fun oAuthClientAuthorizationList(block : OAuthClientAuthorizationList.() -> Unit = {}): OAuthClientAuthorizationList {
+fun newOAuthClientAuthorizationList(block : OAuthClientAuthorizationList.() -> Unit = {}): OAuthClientAuthorizationList {
   val instance = OAuthClientAuthorizationList()
   instance.block()
   return instance
 }
 
 
-fun oAuthClientList(block : OAuthClientList.() -> Unit = {}): OAuthClientList {
+fun newOAuthClientList(block : OAuthClientList.() -> Unit = {}): OAuthClientList {
   val instance = OAuthClientList()
   instance.block()
   return instance
 }
 
 
-fun parameter(block : Parameter.() -> Unit = {}): Parameter {
+fun newParameter(block : Parameter.() -> Unit = {}): Parameter {
   val instance = Parameter()
   instance.block()
   return instance
 }
 
 
-fun policy(block : Policy.() -> Unit = {}): Policy {
+fun newPolicy(block : Policy.() -> Unit = {}): Policy {
   val instance = Policy()
   instance.block()
   return instance
 }
 
 
-fun policyBinding(block : PolicyBinding.() -> Unit = {}): PolicyBinding {
+fun newPolicyBinding(block : PolicyBinding.() -> Unit = {}): PolicyBinding {
   val instance = PolicyBinding()
   instance.block()
   return instance
 }
 
 
-fun policyBindingList(block : PolicyBindingList.() -> Unit = {}): PolicyBindingList {
+fun newPolicyBindingList(block : PolicyBindingList.() -> Unit = {}): PolicyBindingList {
   val instance = PolicyBindingList()
   instance.block()
   return instance
 }
 
 
-fun policyList(block : PolicyList.() -> Unit = {}): PolicyList {
+fun newPolicyList(block : PolicyList.() -> Unit = {}): PolicyList {
   val instance = PolicyList()
   instance.block()
   return instance
 }
 
 
-fun policyRule(block : PolicyRule.() -> Unit = {}): PolicyRule {
+fun newPolicyRule(block : PolicyRule.() -> Unit = {}): PolicyRule {
   val instance = PolicyRule()
   instance.block()
   return instance
 }
 
 
-fun project(block : Project.() -> Unit = {}): Project {
+fun newProject(block : Project.() -> Unit = {}): Project {
   val instance = Project()
   instance.block()
   return instance
 }
 
 
-fun projectList(block : ProjectList.() -> Unit = {}): ProjectList {
+fun newProjectList(block : ProjectList.() -> Unit = {}): ProjectList {
   val instance = ProjectList()
   instance.block()
   return instance
 }
 
 
-fun projectRequest(block : ProjectRequest.() -> Unit = {}): ProjectRequest {
+fun newProjectRequest(block : ProjectRequest.() -> Unit = {}): ProjectRequest {
   val instance = ProjectRequest()
   instance.block()
   return instance
 }
 
 
-fun projectSpec(block : ProjectSpec.() -> Unit = {}): ProjectSpec {
+fun newProjectSpec(block : ProjectSpec.() -> Unit = {}): ProjectSpec {
   val instance = ProjectSpec()
   instance.block()
   return instance
 }
 
 
-fun projectStatus(block : ProjectStatus.() -> Unit = {}): ProjectStatus {
+fun newProjectStatus(block : ProjectStatus.() -> Unit = {}): ProjectStatus {
   val instance = ProjectStatus()
   instance.block()
   return instance
 }
 
 
-fun recreateDeploymentStrategyParams(block : RecreateDeploymentStrategyParams.() -> Unit = {}): RecreateDeploymentStrategyParams {
+fun newRecreateDeploymentStrategyParams(block : RecreateDeploymentStrategyParams.() -> Unit = {}): RecreateDeploymentStrategyParams {
   val instance = RecreateDeploymentStrategyParams()
   instance.block()
   return instance
 }
 
 
-fun role(block : Role.() -> Unit = {}): Role {
+fun newRole(block : Role.() -> Unit = {}): Role {
   val instance = Role()
   instance.block()
   return instance
 }
 
 
-fun roleBinding(block : RoleBinding.() -> Unit = {}): RoleBinding {
+fun newRoleBinding(block : RoleBinding.() -> Unit = {}): RoleBinding {
   val instance = RoleBinding()
   instance.block()
   return instance
 }
 
 
-fun roleBindingList(block : RoleBindingList.() -> Unit = {}): RoleBindingList {
+fun newRoleBindingList(block : RoleBindingList.() -> Unit = {}): RoleBindingList {
   val instance = RoleBindingList()
   instance.block()
   return instance
 }
 
 
-fun roleBindingRestriction(block : RoleBindingRestriction.() -> Unit = {}): RoleBindingRestriction {
+fun newRoleBindingRestriction(block : RoleBindingRestriction.() -> Unit = {}): RoleBindingRestriction {
   val instance = RoleBindingRestriction()
   instance.block()
   return instance
 }
 
 
-fun roleBindingRestrictionSpec(block : RoleBindingRestrictionSpec.() -> Unit = {}): RoleBindingRestrictionSpec {
+fun newRoleBindingRestrictionSpec(block : RoleBindingRestrictionSpec.() -> Unit = {}): RoleBindingRestrictionSpec {
   val instance = RoleBindingRestrictionSpec()
   instance.block()
   return instance
 }
 
 
-fun roleList(block : RoleList.() -> Unit = {}): RoleList {
+fun newRoleList(block : RoleList.() -> Unit = {}): RoleList {
   val instance = RoleList()
   instance.block()
   return instance
 }
 
 
-fun rollingDeploymentStrategyParams(block : RollingDeploymentStrategyParams.() -> Unit = {}): RollingDeploymentStrategyParams {
+fun newRollingDeploymentStrategyParams(block : RollingDeploymentStrategyParams.() -> Unit = {}): RollingDeploymentStrategyParams {
   val instance = RollingDeploymentStrategyParams()
   instance.block()
   return instance
 }
 
 
-fun route(block : Route.() -> Unit = {}): Route {
+fun newRoute(block : Route.() -> Unit = {}): Route {
   val instance = Route()
   instance.block()
   return instance
 }
 
 
-fun routeIngress(block : RouteIngress.() -> Unit = {}): RouteIngress {
+fun newRouteIngress(block : RouteIngress.() -> Unit = {}): RouteIngress {
   val instance = RouteIngress()
   instance.block()
   return instance
 }
 
 
-fun routeIngressCondition(block : RouteIngressCondition.() -> Unit = {}): RouteIngressCondition {
+fun newRouteIngressCondition(block : RouteIngressCondition.() -> Unit = {}): RouteIngressCondition {
   val instance = RouteIngressCondition()
   instance.block()
   return instance
 }
 
 
-fun routeList(block : RouteList.() -> Unit = {}): RouteList {
+fun newRouteList(block : RouteList.() -> Unit = {}): RouteList {
   val instance = RouteList()
   instance.block()
   return instance
 }
 
 
-fun routePort(block : RoutePort.() -> Unit = {}): RoutePort {
+fun newRoutePort(block : RoutePort.() -> Unit = {}): RoutePort {
   val instance = RoutePort()
   instance.block()
   return instance
 }
 
 
-fun routeSpec(block : RouteSpec.() -> Unit = {}): RouteSpec {
+fun newRouteSpec(block : RouteSpec.() -> Unit = {}): RouteSpec {
   val instance = RouteSpec()
   instance.block()
   return instance
 }
 
 
-fun routeStatus(block : RouteStatus.() -> Unit = {}): RouteStatus {
+fun newRouteStatus(block : RouteStatus.() -> Unit = {}): RouteStatus {
   val instance = RouteStatus()
   instance.block()
   return instance
 }
 
 
-fun routeTargetReference(block : RouteTargetReference.() -> Unit = {}): RouteTargetReference {
+fun newRouteTargetReference(block : RouteTargetReference.() -> Unit = {}): RouteTargetReference {
   val instance = RouteTargetReference()
   instance.block()
   return instance
 }
 
 
-fun runAsUserStrategyOptions(block : RunAsUserStrategyOptions.() -> Unit = {}): RunAsUserStrategyOptions {
+fun newRunAsUserStrategyOptions(block : RunAsUserStrategyOptions.() -> Unit = {}): RunAsUserStrategyOptions {
   val instance = RunAsUserStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun seLinuxContextStrategyOptions(block : SELinuxContextStrategyOptions.() -> Unit = {}): SELinuxContextStrategyOptions {
+fun newSELinuxContextStrategyOptions(block : SELinuxContextStrategyOptions.() -> Unit = {}): SELinuxContextStrategyOptions {
   val instance = SELinuxContextStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun scopeRestriction(block : ScopeRestriction.() -> Unit = {}): ScopeRestriction {
+fun newScopeRestriction(block : ScopeRestriction.() -> Unit = {}): ScopeRestriction {
   val instance = ScopeRestriction()
   instance.block()
   return instance
 }
 
 
-fun secretBuildSource(block : SecretBuildSource.() -> Unit = {}): SecretBuildSource {
+fun newSecretBuildSource(block : SecretBuildSource.() -> Unit = {}): SecretBuildSource {
   val instance = SecretBuildSource()
   instance.block()
   return instance
 }
 
 
-fun secretSpec(block : SecretSpec.() -> Unit = {}): SecretSpec {
+fun newSecretSpec(block : SecretSpec.() -> Unit = {}): SecretSpec {
   val instance = SecretSpec()
   instance.block()
   return instance
 }
 
 
-fun securityContextConstraints(block : SecurityContextConstraints.() -> Unit = {}): SecurityContextConstraints {
+fun newSecurityContextConstraints(block : SecurityContextConstraints.() -> Unit = {}): SecurityContextConstraints {
   val instance = SecurityContextConstraints()
   instance.block()
   return instance
 }
 
 
-fun securityContextConstraintsList(block : SecurityContextConstraintsList.() -> Unit = {}): SecurityContextConstraintsList {
+fun newSecurityContextConstraintsList(block : SecurityContextConstraintsList.() -> Unit = {}): SecurityContextConstraintsList {
   val instance = SecurityContextConstraintsList()
   instance.block()
   return instance
 }
 
 
-fun serviceAccountReference(block : ServiceAccountReference.() -> Unit = {}): ServiceAccountReference {
+fun newServiceAccountReference(block : ServiceAccountReference.() -> Unit = {}): ServiceAccountReference {
   val instance = ServiceAccountReference()
   instance.block()
   return instance
 }
 
 
-fun serviceAccountRestriction(block : ServiceAccountRestriction.() -> Unit = {}): ServiceAccountRestriction {
+fun newServiceAccountRestriction(block : ServiceAccountRestriction.() -> Unit = {}): ServiceAccountRestriction {
   val instance = ServiceAccountRestriction()
   instance.block()
   return instance
 }
 
 
-fun signatureCondition(block : SignatureCondition.() -> Unit = {}): SignatureCondition {
+fun newSignatureCondition(block : SignatureCondition.() -> Unit = {}): SignatureCondition {
   val instance = SignatureCondition()
   instance.block()
   return instance
 }
 
 
-fun signatureIssuer(block : SignatureIssuer.() -> Unit = {}): SignatureIssuer {
+fun newSignatureIssuer(block : SignatureIssuer.() -> Unit = {}): SignatureIssuer {
   val instance = SignatureIssuer()
   instance.block()
   return instance
 }
 
 
-fun signatureSubject(block : SignatureSubject.() -> Unit = {}): SignatureSubject {
+fun newSignatureSubject(block : SignatureSubject.() -> Unit = {}): SignatureSubject {
   val instance = SignatureSubject()
   instance.block()
   return instance
 }
 
 
-fun sourceBuildStrategy(block : SourceBuildStrategy.() -> Unit = {}): SourceBuildStrategy {
+fun newSourceBuildStrategy(block : SourceBuildStrategy.() -> Unit = {}): SourceBuildStrategy {
   val instance = SourceBuildStrategy()
   instance.block()
   return instance
 }
 
 
-fun sourceControlUser(block : SourceControlUser.() -> Unit = {}): SourceControlUser {
+fun newSourceControlUser(block : SourceControlUser.() -> Unit = {}): SourceControlUser {
   val instance = SourceControlUser()
   instance.block()
   return instance
 }
 
 
-fun sourceRevision(block : SourceRevision.() -> Unit = {}): SourceRevision {
+fun newSourceRevision(block : SourceRevision.() -> Unit = {}): SourceRevision {
   val instance = SourceRevision()
   instance.block()
   return instance
 }
 
 
-fun stageInfo(block : StageInfo.() -> Unit = {}): StageInfo {
+fun newStageInfo(block : StageInfo.() -> Unit = {}): StageInfo {
   val instance = StageInfo()
   instance.block()
   return instance
 }
 
 
-fun stepInfo(block : StepInfo.() -> Unit = {}): StepInfo {
+fun newStepInfo(block : StepInfo.() -> Unit = {}): StepInfo {
   val instance = StepInfo()
   instance.block()
   return instance
 }
 
 
-fun subjectAccessReview(block : SubjectAccessReview.() -> Unit = {}): SubjectAccessReview {
+fun newSubjectAccessReview(block : SubjectAccessReview.() -> Unit = {}): SubjectAccessReview {
   val instance = SubjectAccessReview()
   instance.block()
   return instance
 }
 
 
-fun subjectAccessReviewResponse(block : SubjectAccessReviewResponse.() -> Unit = {}): SubjectAccessReviewResponse {
+fun newSubjectAccessReviewResponse(block : SubjectAccessReviewResponse.() -> Unit = {}): SubjectAccessReviewResponse {
   val instance = SubjectAccessReviewResponse()
   instance.block()
   return instance
 }
 
 
-fun supplementalGroupsStrategyOptions(block : SupplementalGroupsStrategyOptions.() -> Unit = {}): SupplementalGroupsStrategyOptions {
+fun newSupplementalGroupsStrategyOptions(block : SupplementalGroupsStrategyOptions.() -> Unit = {}): SupplementalGroupsStrategyOptions {
   val instance = SupplementalGroupsStrategyOptions()
   instance.block()
   return instance
 }
 
 
-fun tlsConfig(block : TLSConfig.() -> Unit = {}): TLSConfig {
+fun newTLSConfig(block : TLSConfig.() -> Unit = {}): TLSConfig {
   val instance = TLSConfig()
   instance.block()
   return instance
 }
 
 
-fun tagEvent(block : TagEvent.() -> Unit = {}): TagEvent {
+fun newTagEvent(block : TagEvent.() -> Unit = {}): TagEvent {
   val instance = TagEvent()
   instance.block()
   return instance
 }
 
 
-fun tagEventCondition(block : TagEventCondition.() -> Unit = {}): TagEventCondition {
+fun newTagEventCondition(block : TagEventCondition.() -> Unit = {}): TagEventCondition {
   val instance = TagEventCondition()
   instance.block()
   return instance
 }
 
 
-fun tagImageHook(block : TagImageHook.() -> Unit = {}): TagImageHook {
+fun newTagImageHook(block : TagImageHook.() -> Unit = {}): TagImageHook {
   val instance = TagImageHook()
   instance.block()
   return instance
 }
 
 
-fun tagImportPolicy(block : TagImportPolicy.() -> Unit = {}): TagImportPolicy {
+fun newTagImportPolicy(block : TagImportPolicy.() -> Unit = {}): TagImportPolicy {
   val instance = TagImportPolicy()
   instance.block()
   return instance
 }
 
 
-fun tagReference(block : TagReference.() -> Unit = {}): TagReference {
+fun newTagReference(block : TagReference.() -> Unit = {}): TagReference {
   val instance = TagReference()
   instance.block()
   return instance
 }
 
 
-fun tagReferencePolicy(block : TagReferencePolicy.() -> Unit = {}): TagReferencePolicy {
+fun newTagReferencePolicy(block : TagReferencePolicy.() -> Unit = {}): TagReferencePolicy {
   val instance = TagReferencePolicy()
   instance.block()
   return instance
 }
 
 
-fun template(block : Template.() -> Unit = {}): Template {
+fun newTemplate(block : Template.() -> Unit = {}): Template {
   val instance = Template()
   instance.block()
   return instance
 }
 
 
-fun templateList(block : TemplateList.() -> Unit = {}): TemplateList {
+fun newTemplateList(block : TemplateList.() -> Unit = {}): TemplateList {
   val instance = TemplateList()
   instance.block()
   return instance
 }
 
 
-fun user(block : User.() -> Unit = {}): User {
+fun newUser(block : User.() -> Unit = {}): User {
   val instance = User()
   instance.block()
   return instance
 }
 
 
-fun userList(block : UserList.() -> Unit = {}): UserList {
+fun newUserList(block : UserList.() -> Unit = {}): UserList {
   val instance = UserList()
   instance.block()
   return instance
 }
 
 
-fun userRestriction(block : UserRestriction.() -> Unit = {}): UserRestriction {
+fun newUserRestriction(block : UserRestriction.() -> Unit = {}): UserRestriction {
   val instance = UserRestriction()
   instance.block()
   return instance
 }
 
 
-fun webHookTrigger(block : WebHookTrigger.() -> Unit = {}): WebHookTrigger {
+fun newWebHookTrigger(block : WebHookTrigger.() -> Unit = {}): WebHookTrigger {
   val instance = WebHookTrigger()
   instance.block()
   return instance

--- a/kubernetes/dsl/src/test/kotlin/com/fkorotkov/kubernetes/SimpleCompilationTest.kt
+++ b/kubernetes/dsl/src/test/kotlin/com/fkorotkov/kubernetes/SimpleCompilationTest.kt
@@ -8,7 +8,7 @@ class SimpleCompilationTest {
   @Test
   fun testService() {
     val serviceName = "test"
-    val myService = service {
+    val myService = newService {
       metadata {
         name = serviceName
         labels = mapOf(
@@ -19,12 +19,12 @@ class SimpleCompilationTest {
       spec {
         type = "NodePort"
         ports = listOf(
-          servicePort {
+          newServicePort {
             name = "http"
             port = 8080
             targetPort = IntOrString(8080)
           },
-          servicePort {
+          newServicePort {
             name = "grcp"
             port = 8239
             targetPort = IntOrString(8239)


### PR DESCRIPTION
new prefix prevents confusion between choosing real extension functions that mutate fields and class builders that just create new objects and don't mutate 'outer scope' 